### PR TITLE
fix(ci): configure git identity for rush install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           node-version-file: '.node-version'
 
+      - name: Configure git identity
+        # Rush gitPolicy (rush.json allowedEmailRegExps) requires a @users.noreply.github.com email,
+        # otherwise `rush install` aborts on the runner.
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Install
         run: node common/scripts/install-run-rush.js install
 


### PR DESCRIPTION
CI was failing in ~24s on every run because the GitHub Actions runner has no git user.email configured by default. Rush's `gitPolicy` (`allowedEmailRegExps` in `rush.json`) checks the committer identity during `rush install` and aborts if the email doesn't match — producing an early failure before any compile step runs.

The fix: add a step before `Install` that sets the standard github-actions bot identity. That email (`41898282+github-actions[bot]@users.noreply.github.com`) matches rush.json's `[^@]+@users\.noreply\.github\.com` regex, so gitPolicy passes and install proceeds normally.