### PR TITLE
feat(type-helpers): add Opaque<Type, Scope> branded-type helper

### DIFF
--- a/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-opaque_2026-05-31-05-30.json
+++ b/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-opaque_2026-05-31-05-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add Opaque<Type, Scope> branded-type helper",
+      "type": "minor",
+      "packageName": "@rhombus-toolkit/type-helpers"
+    }
+  ],
+  "packageName": "@rhombus-toolkit/type-helpers",
+  "email": "2511516+fnrhombus@users.noreply.github.com"
+}

--- a/libraries/type-helpers/src/index.ts
+++ b/libraries/type-helpers/src/index.ts
@@ -8,6 +8,7 @@ export * from './deep-record';
 export * from './identity';
 // export * from './Lazy';
 export * from './node-callback-to-async';
+export * from './opaque';
 export * as obj from './obj';
 export * from './range';
 export * from './restify';

--- a/libraries/type-helpers/src/opaque.d.ts
+++ b/libraries/type-helpers/src/opaque.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Brand `Type` with a phantom `Scope` so it is no longer assignable from the
+ * bare underlying type. An `Opaque<string, 'UserId'>` is still usable anywhere a
+ * `string` is wanted, but a plain `string` (or an opaque of a different `Scope`)
+ * is not assignable back to it.
+ *
+ * The brand key is the no-entry string `'⛔'` — emoji aren't valid identifiers,
+ * so nothing outside this file can name the key to forge a value.
+ */
+export type Opaque<Type, Scope extends string | symbol> = Type & { readonly ['⛔']: Scope };


### PR DESCRIPTION
Adds an `Opaque<Type, Scope>` branded-type helper in its own file (`src/opaque.d.ts`) and re-exports it from the package index.

A branded type is still usable wherever the underlying type is wanted, but the bare underlying type (and opaques of a different `Scope`) are not assignable back to it. The brand key is the string `'⛔'` — emoji aren't valid identifiers, so nothing outside the module can name the key to forge a value.

```ts
type UserId = Opaque<string, 'UserId'>;
const id = 'abc' as UserId;   // explicit cast at the boundary
const s: string = id;          // ok — UserId is still a string
const bad: UserId = 'abc';     // error — plain string can't forge the brand
```

Minor bump (new export); `rush change` file included.