### PR TITLE
feat(proxy-base): add IndexAccessed indexer base class

### DIFF
--- a/libraries/proxy-base/package.json
+++ b/libraries/proxy-base/package.json
@@ -9,6 +9,9 @@
   },
   "main": "lib/index.js",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "heft test --clean",
     "build": "heft build --clean",

--- a/libraries/proxy-base/src/IndexAccessed.ts
+++ b/libraries/proxy-base/src/IndexAccessed.ts
@@ -1,0 +1,194 @@
+/**
+ * Internal view of the indexer methods, used to reach them from the
+ * module-level proxy handler. `IndexAccessed` declares the indexers as
+ * `protected`, which TypeScript won't let the handler call from outside the
+ * class body; this interface gives the handler a structural, non-`protected`
+ * view of the same method set so it can dispatch through them.
+ */
+interface Indexer {
+    _getIndex(key: PropertyKey): unknown;
+    _setIndex(key: PropertyKey, value: unknown): unknown;
+}
+
+function createHandler(self: object, proto: object): ProxyHandler<object> {
+    // Look the indexer methods up through the REAL prototype chain (never
+    // through the attached proxy) so dispatch cannot recurse into the traps.
+    // Resolves subclass overrides because `proto` IS the subclass prototype.
+    const indexer = <K extends keyof Indexer>(name: K): Indexer[K] =>
+        Reflect.get(proto, name, self) as Indexer[K];
+
+    return {
+        // get/set walk the prototype chain, so they fire here whenever a lookup
+        // misses the instance's own properties and the entire real chain. The
+        // miss-check restores ordinary behavior for real members, so the
+        // indexer only ever sees true misses.
+        get(target, property, receiver) {
+            if (Reflect.has(target, property)) return Reflect.get(target, property, receiver);
+            return indexer('_getIndex').call(self, property);
+        },
+        set(target, property, value, receiver) {
+            if (Reflect.has(target, property)) return Reflect.set(target, property, value, receiver);
+            indexer('_setIndex').call(self, property, value);
+            return true;
+        },
+        getPrototypeOf() {
+            // The attached proxy stands in front of the real prototype in the
+            // instance's chain; returning the real prototype keeps it visible
+            // to prototype walks so `instance instanceof Subclass` works.
+            return proto;
+        },
+    };
+}
+
+/**
+ * An `abstract` base class that gives subclasses indexer-style property access —
+ * the TypeScript/JavaScript analogue of a C# indexer (`this[key]`).
+ *
+ * Reads and writes of properties that do **not** exist anywhere on the instance
+ * or its real prototype chain route to {@link IndexAccessed._getIndex} and
+ * {@link IndexAccessed._setIndex}. Real members — own properties, declared
+ * fields, and inherited methods — always win; the indexer is a *miss-only*
+ * fallback, never consulted for keys that already resolve.
+ *
+ * Generic over the indexed `Value` type — the value the indexer reads and
+ * writes — and over `Key`, the key type the indexer accepts (defaulting to
+ * `PropertyKey`).
+ *
+ * `Key` is a **compile-time contract only.** The proxy cannot restrict which
+ * keys actually arrive at runtime, so {@link IndexAccessed._getIndex} and
+ * {@link IndexAccessed._setIndex} may still be invoked with keys outside `Key` —
+ * well-known-symbol probes, arbitrary strings written through an `unknown` cast,
+ * and the like. Narrowing `Key` documents intent and tightens the call site for
+ * statically-typed access, but implementations must still handle unrecognized
+ * keys defensively (typically returning `undefined`, cast to `Value` as needed).
+ *
+ * ## Narrowing `Key` past real members
+ *
+ * Real members always shadow the indexer at runtime, so when you narrow `Key`
+ * to a literal union, **exclude the names of the class's own members from it**
+ * — otherwise the `Key` type promises index access to keys that actually
+ * resolve to methods/fields and never reach the indexer. The clean way to do
+ * this is to declare the member surface as an interface and subtract its keys:
+ *
+ * ```ts
+ * type Keys = 'PATH' | 'HOME' | 'refresh';
+ * interface EnvApi { refresh(): void; }
+ * class Env extends IndexAccessed<string, Exclude<Keys, keyof EnvApi>> implements EnvApi {
+ *     // refresh is a real member, so it shadows the indexer and is excluded
+ *     // from Key above.
+ *     refresh(): void {}
+ *     protected _getIndex(key: 'PATH' | 'HOME'): string { return undefined as unknown as string; }
+ *     protected _setIndex(_key: 'PATH' | 'HOME', value: string): string { return value; }
+ * }
+ * ```
+ *
+ * The members-interface indirection is required: the self-referential form
+ * `Exclude<Keys, keyof Env>` written inside `Env`'s own `extends` clause is
+ * rejected by TypeScript (TS2310, recursive base-class reference). With the
+ * default `Key = PropertyKey` no exclusion is needed — the broad
+ * `string | number | symbol` constituents aren't narrowed by excluding literal
+ * member names anyway.
+ *
+ * ## Mechanism
+ *
+ * A `Proxy` is an exotic object and cannot be subclassed with `extends`. Rather
+ * than *being* a proxy, each instance *has* a per-instance `Proxy` spliced into
+ * its prototype chain in place of the real prototype:
+ *
+ * ```text
+ *   instance ──[[Prototype]]──▶ Proxy(realPrototype) ──▶ realPrototype ──▶ …
+ * ```
+ *
+ * The constructor reads the instance's real prototype, wraps it in a `Proxy`
+ * whose handler dispatches to this instance's indexer methods, and sets that
+ * proxy as the instance's `[[Prototype]]`. Only the `get` and `set` traps
+ * participate in JavaScript's prototype-chain walk, which is all this class
+ * needs — so unlike {@link ProxyBase} it deliberately exposes no other hook
+ * surface. The `getPrototypeOf` trap is implemented solely to return the real
+ * prototype, keeping `instanceof` intact.
+ *
+ * ## Hazards
+ *
+ * - **Keys are `PropertyKey`.** Well-known-symbol probes against an
+ *   instance — `Symbol.toStringTag`, `Symbol.iterator`, Node's
+ *   `util.inspect.custom` symbol, and the like — are property reads that miss
+ *   undeclared, so they also reach {@link IndexAccessed._getIndex}.
+ *   Implementations should return `undefined` (cast to `Value` as needed) for
+ *   any key they don't recognize; otherwise iteration, logging, and string
+ *   coercion may misbehave.
+ * - **Constructor-body assignments to undeclared properties route through
+ *   {@link IndexAccessed._setIndex}.** A plain `this.foo = …` in a subclass
+ *   constructor is a `[[Set]]` and, if `foo` isn't otherwise defined, traps as
+ *   an index write. Class **field declarations** (`foo = value`) use
+ *   `[[DefineOwnProperty]]` semantics and do **not** route through the indexer.
+ * - **`key in obj` and `Object.keys(obj)` do not consult the indexer.** There
+ *   is no `has` or `ownKeys` participation; only `get` and `set` are wired up.
+ * - **`Object.getPrototypeOf(instance)` returns the attached proxy**, not the
+ *   real prototype.
+ *
+ * @example
+ * ```ts
+ * class Env extends IndexAccessed<string> {
+ *     readonly #store = new Map<PropertyKey, string>();
+ *
+ *     protected _getIndex(key: PropertyKey): string {
+ *         return this.#store.get(key) ?? (undefined as unknown as string);
+ *     }
+ *
+ *     protected _setIndex(key: PropertyKey, value: string): string {
+ *         this.#store.set(key, value);
+ *         return value;
+ *     }
+ * }
+ *
+ * const env = new Env();
+ * const indexable = env as unknown as Record<string, string>;
+ * indexable['HOME'] = '/home/tom';
+ * indexable['HOME']; // '/home/tom'
+ * env instanceof Env; // true
+ * ```
+ */
+export abstract class IndexAccessed<Value, Key extends PropertyKey = PropertyKey> {
+    constructor() {
+        const prototype = Object.getPrototypeOf(this) as object;
+        Object.setPrototypeOf(this, new Proxy(prototype, createHandler(this, prototype)));
+    }
+
+    /**
+     * Indexer read hook. `protected` and abstract: subclasses **must**
+     * implement it.
+     *
+     * @virtual
+     *
+     * Corresponds to the proxy `get` trap. Because `get` participates in the
+     * prototype-chain walk, it fires for any property read that misses the
+     * instance's own properties and the entire real prototype chain — including
+     * well-known-symbol probes (see the class-level hazards). The `key`
+     * parameter is typed `Key`, but that is a compile-time contract only — at
+     * runtime keys outside `Key` can still arrive, so return `undefined` (cast
+     * to `Value`) for keys you don't recognize.
+     */
+    protected abstract _getIndex(key: Key): Value;
+
+    /**
+     * Indexer write hook. `protected` and abstract: subclasses **must**
+     * implement it.
+     *
+     * @virtual
+     *
+     * Corresponds to the proxy `set` trap. Because `set` participates in the
+     * prototype-chain walk, it fires on assignment to a property that does not
+     * exist on the instance or the real prototype chain.
+     *
+     * As with {@link IndexAccessed._getIndex}, the `key` parameter is typed
+     * `Key` purely as a compile-time contract; keys outside `Key` can still
+     * arrive at runtime.
+     *
+     * The return value is **not** consumed by the proxy machinery — assignments
+     * always report success regardless of what is returned. It exists purely for
+     * subclass ergonomics (e.g. returning the stored value for chaining).
+     */
+    protected abstract _setIndex(key: Key, value: Value): Value;
+}
+
+export default IndexAccessed;

--- a/libraries/proxy-base/src/index.ts
+++ b/libraries/proxy-base/src/index.ts
@@ -1,1 +1,2 @@
 export { ProxyBase, default } from './ProxyBase';
+export { IndexAccessed } from './IndexAccessed';

--- a/tests/src/proxy-base.ts
+++ b/tests/src/proxy-base.ts
@@ -1,4 +1,4 @@
-import { ProxyBase } from "@rhombus-toolkit/proxy-base";
+import { IndexAccessed, ProxyBase } from "@rhombus-toolkit/proxy-base";
 
 class Fallback extends ProxyBase {
     realMethod(): string {
@@ -24,3 +24,57 @@ const a: boolean = f instanceof Fallback;
 const b: boolean = f instanceof ProxyBase;
 
 const m: string = f.realMethod();
+
+class Env extends IndexAccessed<string> {
+    readonly #store = new Map<PropertyKey, string>();
+
+    protected _getIndex(key: PropertyKey): string {
+        return this.#store.get(key) ?? (undefined as unknown as string);
+    }
+
+    protected _setIndex(key: PropertyKey, value: string): string {
+        this.#store.set(key, value);
+        return value;
+    }
+}
+
+const env = new Env();
+
+const indexable = env as unknown as Record<PropertyKey, string>;
+indexable['SOMEKEY'] = 'value';
+const read: string = indexable['SOMEKEY'];
+
+const isEnv: boolean = env instanceof Env;
+const isIndexAccessed: boolean = env instanceof IndexAccessed;
+
+// Narrowed-Key exercise using the members-interface Exclude pattern: real
+// member names are subtracted from the indexed Key union.
+type NarrowedKeys = 'PATH' | 'HOME' | 'refresh';
+interface NarrowedApi {
+    refresh(): void;
+}
+
+class NarrowedEnv extends IndexAccessed<string, Exclude<NarrowedKeys, keyof NarrowedApi>> implements NarrowedApi {
+    readonly #store = new Map<PropertyKey, string>();
+
+    refresh(): void {
+        this.#store.clear();
+    }
+
+    protected _getIndex(key: 'PATH' | 'HOME'): string {
+        return this.#store.get(key) ?? (undefined as unknown as string);
+    }
+
+    protected _setIndex(key: 'PATH' | 'HOME', value: string): string {
+        this.#store.set(key, value);
+        return value;
+    }
+}
+
+const narrowed = new NarrowedEnv();
+const narrowedAccess = narrowed as unknown as Record<'PATH' | 'HOME', string>;
+narrowedAccess['PATH'] = '/usr/bin';
+const narrowedRead: string = narrowedAccess['HOME'];
+narrowed.refresh();
+
+const isNarrowed: boolean = narrowed instanceof NarrowedEnv;


### PR DESCRIPTION
## Summary

- Adds `IndexAccessed<Value, Key extends PropertyKey = PropertyKey>` in `libraries/proxy-base/src/IndexAccessed.ts` — a C#-style indexer base class (`this[key]`). Reads/writes of properties that exist nowhere on the instance or its real prototype chain route to `_getIndex`/`_setIndex`; real members always win (miss-only fallback). The class has **no public members**.
- **Minimal-surface by design vs `ProxyBase`.** Rather than inheriting `ProxyBase` and its full eleven-hook surface, `IndexAccessed` re-implements the same per-instance prototype-proxy technique standalone and exposes only two abstract hooks. The constructor swaps the instance's prototype for a per-instance `Proxy` wrapping the real prototype; only `get`/`set` participate in prototype-chain walks (all this class needs), plus a `getPrototypeOf` trap that returns the real prototype so `instanceof` keeps working.
- `Key` is a **compile-time contract only** — the proxy cannot restrict which keys arrive at runtime, so implementations must still handle unrecognized keys defensively (typically returning `undefined`, cast as needed).
- Class-level JSDoc documents a recommended pattern for narrowing `Key` past real members: real members always shadow the indexer at runtime, so subtract the class's member names from `Key`. The clean form is `IndexAccessed<string, Exclude<Keys, keyof EnvApi>>` against a members interface — the self-referential `Exclude<Keys, keyof Env>` inside `Env`'s own `extends` clause is rejected by TS (TS2310). The narrowed type test proves the doc example.
- Adds `publishConfig.access=public` to the package — the scoped package is unpublished and the first 1.0.0 publish fails with E402 without it.

### Documented hazards (in JSDoc)

- Keys are `PropertyKey`: well-known-symbol probes (`Symbol.toStringTag`, `Symbol.iterator`, Node's inspect symbol) on undeclared properties reach `_getIndex` — return `undefined` (cast as needed) for unrecognized keys or iteration/logging may misbehave.
- Constructor-body assignments to undeclared properties route through `_setIndex`; declared class fields use define semantics and do not.
- `key in obj` and `Object.keys` do not consult the indexer (no `has`/`ownKeys` participation).
- `Object.getPrototypeOf(instance)` returns the attached proxy.

`ProxyBase.ts` already marked every protected hook `protected` + `@virtual`; no change needed there. No new change file — the pending major change file for the unpublished package covers it.

## Test plan

- [x] `rush rebuild` green (library build + tests project `tsc --noEmit`).
- [x] Typed exercises in `tests/src/proxy-base.ts`: `IndexAccessed<string>` (default Key) and a narrowed `IndexAccessed<string, Exclude<Keys, keyof NarrowedApi>>` using the members-interface pattern, proving the doc example.
- [x] Runtime smoke against compiled `lib`: missing-prop read/write round-trips via `_getIndex`/`_setIndex`; real method + declared field never hit the indexer; `instanceof` both ways; symbol-key miss reaches `_getIndex`; `Object.keys`/`JSON.stringify` see only real own props.