### PR TITLE
chore(rush): add prettier pre-commit formatting hook

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Rush machinery — generated configs, scripts, and change files
+common/
+
+# Build outputs
+lib/
+dist/
+temp/
+coverage/
+
+# Generated
+CHANGELOG.md
+CHANGELOG.json
+pnpm-lock.yaml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "tabWidth": 4,
+    "printWidth": 120,
+    "singleQuote": true,
+    "endOfLine": "lf"
+}

--- a/common/autoinstallers/rush-prettier/package.json
+++ b/common/autoinstallers/rush-prettier/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rush-prettier",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "prettier": "~3.8.3",
+    "pretty-quick": "~4.2.2"
+  }
+}

--- a/common/autoinstallers/rush-prettier/pnpm-lock.yaml
+++ b/common/autoinstallers/rush-prettier/pnpm-lock.yaml
@@ -1,0 +1,84 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      prettier:
+        specifier: ~3.8.3
+        version: 3.8.3
+      pretty-quick:
+        specifier: ~4.2.2
+        version: 4.2.2(prettier@3.8.3)
+
+packages:
+
+  '@pkgr/core@0.2.10':
+    resolution: {integrity: sha512-x6fFWCeak8aCGfqZfe6CXYt5xVjxe9Os1cIPmVRcToInKLjhJkRVXvJ/L3/1KxFkjDQdbZV/YsuLKqa8t/xKpA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  pretty-quick@4.2.2:
+    resolution: {integrity: sha512-uAh96tBW1SsD34VhhDmWuEmqbpfYc/B3j++5MC/6b3Cb8Ow7NJsvKFhg0eoGu2xXX+o9RkahkTK6sUdd8E7g5w==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+snapshots:
+
+  '@pkgr/core@0.2.10': {}
+
+  ignore@7.0.5: {}
+
+  mri@1.2.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  prettier@3.8.3: {}
+
+  pretty-quick@4.2.2(prettier@3.8.3):
+    dependencies:
+      '@pkgr/core': 0.2.10
+      ignore: 7.0.5
+      mri: 1.2.0
+      picocolors: 1.1.1
+      picomatch: 4.0.4
+      prettier: 3.8.3
+      tinyexec: 0.3.2
+      tslib: 2.8.1
+
+  tinyexec@0.3.2: {}
+
+  tslib@2.8.1: {}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -11,6 +11,14 @@
    * "rush my-global-command --help".
    */
   "commands": [
+    {
+      "name": "prettier",
+      "commandKind": "global",
+      "summary": "Used by the pre-commit Git hook. This command invokes Prettier to reformat staged changes.",
+      "autoinstallerName": "rush-prettier",
+      "safeForSimultaneousRushProcesses": true,
+      "shellCommand": "pretty-quick --staged"
+    },
     // {
     //   /**
     //    * (Required) Determines the type of custom command.

--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Called by "git commit" with no arguments. The hook should exit with non-zero
+# status after issuing an appropriate message if it wants to stop the commit.
+#
+# Invoke the "rush prettier" custom command to reformat files whenever they
+# are committed. The command is defined in common/config/rush/command-line.json
+# and uses the "rush-prettier" autoinstaller.
+node common/scripts/install-run-rush.js prettier || exit $?


### PR DESCRIPTION
Rush-standard prettier setup:

- `common/autoinstallers/rush-prettier` — prettier ~3.8.3 + pretty-quick ~4.2.2
- global `rush prettier` command (`pretty-quick --staged`) in command-line.json
- `common/git-hooks/pre-commit` — installed into `.git/hooks` by `rush install`
- `.prettierrc.json` from house style: 4-space indent, single quotes, 120 cols, LF
- `.prettierignore`: `common/`, build outputs, changelogs, lockfiles

The hook formats staged files only (progressive adoption — no big-bang reformat). Validated end-to-end: `rush prettier` autoinstalled and reformatted a staged file correctly.

Note: in the main checkout, run `rush install` once after merging to activate the hook.