### PR TITLE
feat(typed-pluralizer): add to-adverb converter

### DIFF
--- a/libraries/typed-pluralizer/src/converter/to-adverb.d.test.ts
+++ b/libraries/typed-pluralizer/src/converter/to-adverb.d.test.ts
@@ -1,0 +1,376 @@
+import { ToAdverb } from './to-adverb';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// Empirically verified against a node oracle that transcribes
+// http://compromise.cool/website/browse/to_adverb.html exactly (dont-list ->
+// null, irregular map, str.length<=3 guard, not_matches, first-match
+// transforms, +ly fall-through). Every assertion below resolves to the literal
+// the oracle produces (modulo the accepted lowercase divergence). Upstream
+// null / no-conversion maps to `never`. Word lists for the irregular map and
+// dont list are generated from the upstream data, not hand-typed.
+//
+// NOTE on enforcement: the heft-web-rig build treats `*.d.test.ts` as a `.d.ts`
+// declaration file and runs with `skipLibCheck: true`, so these assertion bodies
+// are NOT type-checked during `heft build` (the same is true of the existing
+// conjugator/from-infinitive.d.test.ts). To run them as a real gate, type-check
+// this file as a normal module, e.g.:
+//   tsc --noEmit --strict --module ESNext --moduleResolution Bundler \
+//       <copy-of-this-file>.ts
+// All assertions here pass that check with zero errors.
+
+namespace irregularMap {
+    // full membership of the irregular adjective->adverb map
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'idle'>, 'idly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'public'>, 'publicly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'vague'>, 'vaguely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'day'>, 'daily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'icy'>, 'icily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'single'>, 'singly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'female'>, 'womanly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'male'>, 'manly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'simple'>, 'simply'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'whole'>, 'wholly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'special'>, 'especially'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'straight'>, 'straight'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'wrong'>, 'wrong'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'fast'>, 'fast'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'hard'>, 'hard'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'late'>, 'late'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'early'>, 'early'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'well'>, 'well'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'best'>, 'best'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'latter'>, 'latter'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'bad'>, 'badly'>;
+}
+
+namespace dontList {
+    // full membership of the dont list (no adverb form -> never)
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'foreign'>, never>; // 'foreign' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'black'>, never>; // 'black' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'modern'>, never>; // 'modern' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'next'>, never>; // 'next' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'difficult'>, never>; // 'difficult' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'degenerate'>, never>; // 'degenerate' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'young'>, never>; // 'young' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'awake'>, never>; // 'awake' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'back'>, never>; // 'back' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'blue'>, never>; // 'blue' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'brown'>, never>; // 'brown' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'orange'>, never>; // 'orange' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'complex'>, never>; // 'complex' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'cool'>, never>; // 'cool' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'dirty'>, never>; // 'dirty' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'done'>, never>; // 'done' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'empty'>, never>; // 'empty' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'fat'>, never>; // 'fat' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'fertile'>, never>; // 'fertile' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'frozen'>, never>; // 'frozen' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'gold'>, never>; // 'gold' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'grey'>, never>; // 'grey' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'gray'>, never>; // 'gray' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'green'>, never>; // 'green' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'medium'>, never>; // 'medium' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'parallel'>, never>; // 'parallel' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'outdoor'>, never>; // 'outdoor' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'unknown'>, never>; // 'unknown' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'undersized'>, never>; // 'undersized' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'used'>, never>; // 'used' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'welcome'>, never>; // 'welcome' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'yellow'>, never>; // 'yellow' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'white'>, never>; // 'white' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'fixed'>, never>; // 'fixed' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'mixed'>, never>; // 'mixed' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'super'>, never>; // 'super' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'guilty'>, never>; // 'guilty' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'tiny'>, never>; // 'tiny' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'able'>, never>; // 'able' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'unable'>, never>; // 'unable' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'same'>, never>; // 'same' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'adult'>, never>; // 'adult' -> null
+}
+
+namespace transform_al_____ally {
+    // transform: al$ -> ally
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'normal'>, 'normally'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'final'>, 'finally'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'equal'>, 'equally'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'usual'>, 'usually'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'loyal'>, 'loyally'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'total'>, 'totally'>;
+}
+
+namespace transform_ly_____ly__4__char__non_irregular_ {
+    // transform: ly$ -> ly (4+ char, non-irregular)
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'holy'>, 'holy'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'ugly'>, 'ugly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'wily'>, 'wily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'curly'>, 'curly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'silly'>, 'silly'>;
+}
+
+namespace transform____3__y______1ily {
+    // transform: (.{3})y$ -> $1ily
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'happy'>, 'happily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'lucky'>, 'luckily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'tidy'>, 'tidily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'fairy'>, 'fairily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'merry'>, 'merrily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'crazy'>, 'crazily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'pretty'>, 'prettily'>;
+}
+
+namespace transform_que_____quely {
+    // transform: que$ -> quely
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'unique'>, 'uniquely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'opaque'>, 'opaquely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'grotesque'>, 'grotesquely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'antique'>, 'antiquely'>;
+}
+
+namespace transform_ue_____uly {
+    // transform: ue$ -> uly
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'true'>, 'truly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'clue'>, 'cluly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'value'>, 'valuly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'argue'>, 'arguly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'queue'>, 'queuly'>;
+}
+
+namespace transform_ic_____ically {
+    // transform: ic$ -> ically
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'basic'>, 'basically'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'music'>, 'musically'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'magic'>, 'magically'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'toxic'>, 'toxically'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'tragic'>, 'tragically'>;
+}
+
+namespace transform_ble_____bly {
+    // transform: ble$ -> bly
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'terrible'>, 'terribly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'stable'>, 'stably'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'noble'>, 'nobly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'double'>, 'doubly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'horrible'>, 'horribly'>;
+}
+
+namespace transform_l_____ly {
+    // transform: l$ -> ly
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'cruel'>, 'cruely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'civil'>, 'civily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'evil'>, 'evily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'level'>, 'levely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'cool'>, never>; // 'cool' -> null
+}
+
+namespace notMatch_airs_ {
+    // not_match: /airs$/ -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'fairs'>, never>; // 'fairs' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'stairs'>, never>; // 'stairs' -> null
+}
+
+namespace notMatch_ll_ {
+    // not_match: /ll$/ -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'tall'>, never>; // 'tall' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'small'>, never>; // 'small' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'ball'>, never>; // 'ball' -> null
+}
+
+namespace notMatch_ee__ {
+    // not_match: /ee.$/ -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'agree'>, 'agreely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'freed'>, never>; // 'freed' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'speed'>, never>; // 'speed' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'three'>, 'threely'>;
+}
+
+namespace notMatch_ile_ {
+    // not_match: /ile$/ -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'mile'>, never>; // 'mile' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'while'>, never>; // 'while' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'smile'>, never>; // 'smile' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'facile'>, never>; // 'facile' -> null
+}
+
+namespace boundaryLengths {
+    // length guard: 1-3 char words -> null (str.length <= 3); 4-char passes
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'a'>, never>; // 'a' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'ab'>, never>; // 'ab' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'abc'>, never>; // 'abc' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'abcd'>, 'abcdly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'sky'>, never>; // 'sky' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'dry'>, never>; // 'dry' -> null
+}
+
+namespace fallThrough {
+    // no rule matches -> str + ly
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'quick'>, 'quickly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'slow'>, 'slowly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'warm'>, 'warmly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'cold'>, 'coldly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'great'>, 'greatly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'strange'>, 'strangely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'quiet'>, 'quietly'>;
+}
+
+namespace crossArmPriority {
+    // dont/irregular checked before transforms; ordering probes
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'guilty'>, never>; // 'guilty' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'able'>, never>; // 'able' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'parallel'>, never>; // 'parallel' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'super'>, never>; // 'super' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'welcome'>, never>; // 'welcome' -> null
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'subtle'>, 'subtlely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'gentle'>, 'gentlely'>;
+}
+
+namespace caseFolding {
+    // Accepted divergence: input folded through Lowercase<T>, output lowercase;
+    // upstream /i regexes preserve case.
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'HAPPY'>, 'happily'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'Public'>, 'publicly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdverb<'Foreign'>, never>;
+}

--- a/libraries/typed-pluralizer/src/converter/to-adverb.ts
+++ b/libraries/typed-pluralizer/src/converter/to-adverb.ts
@@ -1,0 +1,135 @@
+// http://compromise.cool/website/browse/to_adverb.html
+import { Letter } from '../util';
+
+// Irregular adjective -> adverb map. Exact full-word lookups, checked AFTER the
+// `dont` list but BEFORE the short-word length guard, so the <=3-char entries
+// (`day`, `icy`, `bad`) still resolve.
+type irregulars = {
+    idle: 'idly'; // 'idle': 'idly'
+    public: 'publicly'; // 'public': 'publicly'
+    vague: 'vaguely'; // 'vague': 'vaguely'
+    day: 'daily'; // 'day': 'daily'
+    icy: 'icily'; // 'icy': 'icily'
+    single: 'singly'; // 'single': 'singly'
+    female: 'womanly'; // 'female': 'womanly'
+    male: 'manly'; // 'male': 'manly'
+    simple: 'simply'; // 'simple': 'simply'
+    whole: 'wholly'; // 'whole': 'wholly'
+    special: 'especially'; // 'special': 'especially'
+    straight: 'straight'; // 'straight': 'straight'
+    wrong: 'wrong'; // 'wrong': 'wrong'
+    fast: 'fast'; // 'fast': 'fast'
+    hard: 'hard'; // 'hard': 'hard'
+    late: 'late'; // 'late': 'late'
+    early: 'early'; // 'early': 'early'
+    well: 'well'; // 'well': 'well'
+    best: 'best'; // 'best': 'best'
+    latter: 'latter'; // 'latter': 'latter'
+    bad: 'badly'; // 'bad': 'badly'
+};
+
+// `dont` list: adjectives that have no adverb form. Upstream returns `null` for
+// these; the typed equivalent is `never`. Exact full-word lookups, checked
+// first of all.
+type dont =
+    | 'foreign' // 'foreign': 1
+    | 'black' // 'black': 1
+    | 'modern' // 'modern': 1
+    | 'next' // 'next': 1
+    | 'difficult' // 'difficult': 1
+    | 'degenerate' // 'degenerate': 1
+    | 'young' // 'young': 1
+    | 'awake' // 'awake': 1
+    | 'back' // 'back': 1
+    | 'blue' // 'blue': 1
+    | 'brown' // 'brown': 1
+    | 'orange' // 'orange': 1
+    | 'complex' // 'complex': 1
+    | 'cool' // 'cool': 1
+    | 'dirty' // 'dirty': 1
+    | 'done' // 'done': 1
+    | 'empty' // 'empty': 1
+    | 'fat' // 'fat': 1
+    | 'fertile' // 'fertile': 1
+    | 'frozen' // 'frozen': 1
+    | 'gold' // 'gold': 1
+    | 'grey' // 'grey': 1
+    | 'gray' // 'gray': 1
+    | 'green' // 'green': 1
+    | 'medium' // 'medium': 1
+    | 'parallel' // 'parallel': 1
+    | 'outdoor' // 'outdoor': 1
+    | 'unknown' // 'unknown': 1
+    | 'undersized' // 'undersized': 1
+    | 'used' // 'used': 1
+    | 'welcome' // 'welcome': 1
+    | 'yellow' // 'yellow': 1
+    | 'white' // 'white': 1
+    | 'fixed' // 'fixed': 1
+    | 'mixed' // 'mixed': 1
+    | 'super' // 'super': 1
+    | 'guilty' // 'guilty': 1
+    | 'tiny' // 'tiny': 1
+    | 'able' // 'able': 1
+    | 'unable' // 'unable': 1
+    | 'same' // 'same': 1
+    | 'adult'; // 'adult': 1
+
+// Words of length 1, 2 or 3 enumerated structurally. Upstream guards with
+// `if (str.length <= 3) return null;` AFTER the `dont`/`irregulars` lookups, so
+// this is applied in that same position below — short irregulars like `bad`,
+// `day`, `icy` are already resolved before we get here.
+type ShortWord = `${Letter}` | `${Letter}${Letter}` | `${Letter}${Letter}${Letter}`;
+
+// `not_matches`: case-sensitive suffix patterns that suppress conversion
+// (`return null`). Folded to `never`. Checked after the length guard, before
+// the transforms.
+//   /airs$/  /ll$/  /ee.$/  /ile$/
+type NotMatch =
+    | `${string}airs` // /airs$/
+    | `${string}ll` // /ll$/
+    | `${string}ee${Letter}` // /ee.$/  (. = any single letter)
+    | `${string}ile`; // /ile$/
+
+// Matching is case-insensitive (input is folded to lowercase first); output is
+// always lowercase. Upstream `null` / no-conversion maps to `never`. The
+// accepted divergence from upstream: upstream `/i` regexes preserve the
+// original case, here everything is lowercased via the `Lowercase<T>` fold.
+export type ToAdverb<T extends string> = _ToAdverb<Lowercase<T>>;
+
+type _ToAdverb<T> =
+    // if (dont[str]) { return null; }
+    T extends dont ? never
+    : // if (irregulars[str]) { return irregulars[str]; }
+    T extends keyof irregulars ? irregulars[T]
+    : // if (str.length <= 3) { return null; }
+    T extends ShortWord ? never
+    : // not_matches: if (str.match(...)) { return null; }
+    T extends NotMatch ? never
+    : // transforms (first match wins):
+    // { reg: /al$/i, repl: 'ally' }
+    T extends `${infer X}al` ? `${X}ally`
+    : // { reg: /ly$/i, repl: 'ly' }
+    T extends `${string}ly` ? T
+    : // { reg: /(.{3})y$/i, repl: '$1ily' }  (>=3 letters before the final y)
+    // The captured `(.{3})` is replaced verbatim, so the net effect is: strip the
+    // trailing `y` and append `ily`. The three mandatory `${Letter}`s enforce the
+    // `.{3}` guard structurally.
+    T extends `${string}${Letter}${Letter}${Letter}y` ? `${StripFinalY<T>}ily`
+    : // { reg: /que$/i, repl: 'quely' }
+    T extends `${infer X}que` ? `${X}quely`
+    : // { reg: /ue$/i, repl: 'uly' }
+    T extends `${infer X}ue` ? `${X}uly`
+    : // { reg: /ic$/i, repl: 'ically' }
+    T extends `${infer X}ic` ? `${X}ically`
+    : // { reg: /ble$/i, repl: 'bly' }
+    T extends `${infer X}ble` ? `${X}bly`
+    : // { reg: /l$/i, repl: 'ly' }
+    T extends `${infer X}l` ? `${X}ly`
+    : // fall-through: return str + 'ly';
+    T extends string ? `${T}ly`
+    : never;
+
+// Drops a single trailing `y`. Used by the `/(.{3})y$/ -> $1ily` arm above,
+// which keeps the captured 3 chars verbatim and only swaps `y` for `ily`.
+type StripFinalY<T> = T extends `${infer Base}y` ? Base : T;


### PR DESCRIPTION
Adds `libraries/typed-pluralizer/src/converter/to-adverb.ts` — a conditional-type port of compromise's `to_adverb` adjective→adverb conversion (http://compromise.cool/website/browse/to_adverb.html). New `src/converter/` directory; no `index.ts` barrel (export wiring is a later PR).

## What changed

- `ToAdverb<T>` public wrapper folds `Lowercase<T>` into the `_ToAdverb<T>` internal, mirroring the `pluralization-rules.ts` / `from-infinitive.ts` style.
- Control flow transcribed in upstream order, with the source JS comment adjacent to every arm/entry:
  1. `dont` list (42 words) → `never` (upstream `return null`)
  2. irregular map (21 entries) → mapped literal
  3. `str.length <= 3` short-word guard → `never`, enumerated structurally as `${Letter} | ${Letter}${Letter} | ${Letter}${Letter}${Letter}` (types can't compare lengths numerically)
  4. four `not_matches` patterns (`/airs$/`, `/ll$/`, `/ee.$/`, `/ile$/`) → `never`
  5. eight first-match transforms (`al$`→ally, `ly$`→ly, `(.{3})y$`→\$1ily, `que$`→quely, `ue$`→uly, `ic$`→ically, `ble$`→bly, `l$`→ly)
  6. `+ly` fall-through
- `(.{3})y$ → $1ily` is implemented as "≥3 letters before the final `y` ⇒ strip `y`, append `ily`" — the captured 3 chars are kept verbatim by the regex, so this is exactly equivalent.
- Added `to-adverb.d.test.ts`. The irregular-map and dont-list membership assertions are **generated from the upstream data by script**, not hand-typed; plus ≥2 positives per transform, all four not-match probes, boundary lengths 1–4, cross-arm priority probes, fall-through, and case-folding.

No new `util` helpers were needed (only a small file-local `StripFinalY`).

## How verified

- Built a node oracle that transcribes the upstream JS exactly (iteration order, first-match short-circuit, the gate ordering where `dont`/irregulars are checked before the length guard).
- Resolved every word's actual type via the tsc sentinel-assignment probe against this package's `tsc`.
- **174-word dataset: oracle and types agree on every case** — full irregular + dont membership, every transform with multiple positives, all four not-match patterns, boundary lengths 1–4, cross-arm collisions (e.g. `guilty`/`able`/`parallel` correctly suppressed by the earlier `dont` check), and fall-through words.
- The `.d.test.ts` compiles clean as a standalone strict module (every `@ts-expect-no-error` holds).

## Divergences (documented, not silent)

- **Accepted (the only intended one):** matching is case-insensitive via the `Lowercase<T>` fold and output is always lowercase; upstream `/i` regexes preserve case.
- **Build enforcement:** the heft-web-rig build treats `*.d.test.ts` as a `.d.ts` file under `skipLibCheck`, so the assertion bodies are not type-checked by `heft build` — the same is true of the existing `conjugator/from-infinitive.d.test.ts`. The assertions are a real gate when the file is type-checked as a normal module (verified here, zero errors); this is noted in a comment at the top of the test file.