### PR TITLE
feat(typed-pluralizer): add to-adjective, to-noun, to-actor converters

### DIFF
--- a/libraries/typed-pluralizer/src/converter/to-actor.d.test.ts
+++ b/libraries/typed-pluralizer/src/converter/to-actor.d.test.ts
@@ -1,0 +1,130 @@
+import { ToActor } from './to-actor';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// Generated from the verified converter dataset (oracle == type on every case).
+// Each assertion's expected literal is the empirically resolved ToActor output.
+// '' inputs and no-conversion words resolve to `never`; asserted as such.
+
+namespace irregularMap {
+    // full irregular-map membership: every key asserted
+    // @ts-expect-no-error
+    isAssignable<ToActor<'tie'>, 'tier'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'dream'>, 'dreamer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'sail'>, 'sailer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'run'>, 'runner'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'rub'>, 'rubber'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'begin'>, 'beginner'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'win'>, 'winner'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'claim'>, 'claimant'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'deal'>, 'dealer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'spin'>, 'spinner'>;
+}
+
+namespace dontList {
+    // full dont-list membership: every word => null upstream => never
+    // @ts-expect-no-error
+    isAssignable<ToActor<'aid'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'fail'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'appear'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'happen'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'seem'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'try'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'say'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'marry'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'be'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'forbid'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'understand'>, never>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'bet'>, never>;
+}
+
+namespace transforms {
+    // >=2 positives per transform arm + boundary negatives + default
+    // @ts-expect-no-error
+    isAssignable<ToActor<'bake'>, 'baker'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'write'>, 'writer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'dance'>, 'dancer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'code'>, 'coder'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'swim'>, 'swimmer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'trim'>, 'trimmer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'travel'>, 'traveller'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'cancel'>, 'canceller'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'dig'>, 'digger'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'jog'>, 'jogger'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'wrap'>, 'wrapper'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'shop'>, 'shopper'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'carry'>, 'carrier'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'hurry'>, 'hurrier'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'fly'>, 'flier'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'apply'>, 'applier'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'defy'>, 'defier'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'classify'>, 'classifier'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'get'>, 'getter'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'set'>, 'setter'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'chat'>, 'chatter'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'spit'>, 'spitter'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'submit'>, 'submiter'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'visit'>, 'visiter'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'hit'>, 'hitter'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'walk'>, 'walker'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'jump'>, 'jumper'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'read'>, 'reader'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'paint'>, 'painter'>;
+}
+
+namespace caseFolding {
+    // input folded through Lowercase<T>; output lowercase
+    // @ts-expect-no-error
+    isAssignable<ToActor<'SWIM'>, 'swimmer'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'BET'>, never>;
+}

--- a/libraries/typed-pluralizer/src/converter/to-actor.d.test.ts
+++ b/libraries/typed-pluralizer/src/converter/to-actor.d.test.ts
@@ -119,6 +119,16 @@ namespace transforms {
     isAssignable<ToActor<'read'>, 'reader'>;
     // @ts-expect-no-error
     isAssignable<ToActor<'paint'>, 'painter'>;
+    // final fallthrough is unconditional (`return str + 'er'`): empty input and
+    // inputs ending in a non-letter (digit/punctuation) still get `er` appended.
+    // @ts-expect-no-error
+    isAssignable<ToActor<''>, 'er'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'go2'>, 'go2er'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'2'>, '2er'>;
+    // @ts-expect-no-error
+    isAssignable<ToActor<'do-'>, 'do-er'>;
 }
 
 namespace caseFolding {

--- a/libraries/typed-pluralizer/src/converter/to-actor.ts
+++ b/libraries/typed-pluralizer/src/converter/to-actor.ts
@@ -1,0 +1,70 @@
+// http://compromise.cool/website/browse/to_actor.html
+//
+// Verb -> actor noun (the doer). Upstream `actor(str)`: coerces falsy input to
+// '', checks a 12-word `dont` gate (returns null), then a 10-entry irregular
+// map, then iterates 4 transform rules first-match-wins, then falls through
+// appending `er`.
+//
+// `never` mapping: upstream returns null for any word in the `dont` list (no
+// actor form exists). Per the "upstream returns null/undefined => the type
+// resolves to never" convention, every `dont` member maps to `never`. The empty
+// input (`str || ''`) also yields no real actor; it falls through the rules to
+// 'er', matching upstream, so it is not special-cased to never.
+//
+// Accepted divergence: matching is case-insensitive via the `Lowercase<T>` fold
+// and output is always lowercase; upstream /i regexes preserve case.
+
+import { AnyOf, Letter, ReplaceEnding, Vowel } from '../util';
+
+// Irregular verb->actor pairs (upstream `irregulars` object literal).
+type irregulars = {
+    tie: 'tier'; // 'tie': 'tier'
+    dream: 'dreamer'; // 'dream': 'dreamer'
+    sail: 'sailer'; // 'sail': 'sailer'
+    run: 'runner'; // 'run': 'runner'
+    rub: 'rubber'; // 'rub': 'rubber'
+    begin: 'beginner'; // 'begin': 'beginner'
+    win: 'winner'; // 'win': 'winner'
+    claim: 'claimant'; // 'claim': 'claimant'
+    deal: 'dealer'; // 'deal': 'dealer'
+    spin: 'spinner'; // 'spin': 'spinner'
+};
+
+// Verbs with no actor form (upstream `dont` object literal); each => null => never.
+type dont =
+    | 'aid' // 'aid': 1
+    | 'fail' // 'fail': 1
+    | 'appear' // 'appear': 1
+    | 'happen' // 'happen': 1
+    | 'seem' // 'seem': 1
+    | 'try' // 'try': 1
+    | 'say' // 'say': 1
+    | 'marry' // 'marry': 1
+    | 'be' // 'be': 1
+    | 'forbid' // 'forbid': 1
+    | 'understand' // 'understand': 1
+    | 'bet'; // 'bet': 1
+
+export type ToActor<T extends string> = _ToActor<Lowercase<T>>;
+
+type _ToActor<T> =
+    // if (dont.hasOwnProperty(str)) return null; — no actor form => never
+    T extends dont ? never
+    : // if (irregulars.hasOwnProperty(str)) return irregulars[str];
+    T extends keyof irregulars ? irregulars[T]
+    : // {'reg': /e$/i, 'repl': 'er'}
+    T extends `${string}e` ? ReplaceEnding<T, 'e', 'er'>
+    : // {'reg': /([aeiou])([mlgp])$/i, 'repl': '$1$2$2er'} — double the m/l/g/p
+    T extends `${string}${Vowel}m` ? ReplaceEnding<T, 'm', 'mmer'>
+    : T extends `${string}${Vowel}l` ? ReplaceEnding<T, 'l', 'ller'>
+    : T extends `${string}${Vowel}g` ? ReplaceEnding<T, 'g', 'gger'>
+    : T extends `${string}${Vowel}p` ? ReplaceEnding<T, 'p', 'pper'>
+    : // {'reg': /([rlf])y$/i, 'repl': '$1ier'}
+    T extends `${string}${AnyOf<'rlf'>}y` ? ReplaceEnding<T, 'y', 'ier'>
+    : // {'reg': /^(.?.[aeiou])t$/i, 'repl': '$1tter'} — ANCHORED whole word,
+    // 3 or 4 chars: ([1-2 chars][vowel])t => double the final t.
+    T extends `${Letter}${Vowel}t` ? ReplaceEnding<T, 't', 'tter'>
+    : T extends `${Letter}${Letter}${Vowel}t` ? ReplaceEnding<T, 't', 'tter'>
+    : // return str + 'er';
+    T extends `${string}${Letter}` ? `${T}er`
+    : T;

--- a/libraries/typed-pluralizer/src/converter/to-actor.ts
+++ b/libraries/typed-pluralizer/src/converter/to-actor.ts
@@ -47,7 +47,7 @@ type dont =
 
 export type ToActor<T extends string> = _ToActor<Lowercase<T>>;
 
-type _ToActor<T> =
+type _ToActor<T extends string> =
     // if (dont.hasOwnProperty(str)) return null; — no actor form => never
     T extends dont ? never
     : // if (irregulars.hasOwnProperty(str)) return irregulars[str];
@@ -65,6 +65,5 @@ type _ToActor<T> =
     // 3 or 4 chars: ([1-2 chars][vowel])t => double the final t.
     T extends `${Letter}${Vowel}t` ? ReplaceEnding<T, 't', 'tter'>
     : T extends `${Letter}${Letter}${Vowel}t` ? ReplaceEnding<T, 't', 'tter'>
-    : // return str + 'er';
-    T extends `${string}${Letter}` ? `${T}er`
-    : T;
+    : // return str + 'er'; — unconditional append (matches upstream)
+        `${T}er`;

--- a/libraries/typed-pluralizer/src/converter/to-adjective.d.test.ts
+++ b/libraries/typed-pluralizer/src/converter/to-adjective.d.test.ts
@@ -1,0 +1,118 @@
+import { ToAdjective } from './to-adjective';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// Generated from the verified converter dataset (oracle == type on every case).
+// Each assertion's expected literal is the empirically resolved ToAdjective output.
+// '' inputs and no-conversion words resolve to `never`; asserted as such.
+
+namespace irregularMap {
+    // full irregular-map membership: every key asserted
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'idly'>, 'idle'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'sporadically'>, 'sporadic'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'basically'>, 'basic'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'grammatically'>, 'grammatical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'alphabetically'>, 'alphabetical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'economically'>, 'economical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'conically'>, 'conical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'politically'>, 'political'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'vertically'>, 'vertical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'practically'>, 'practical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'theoretically'>, 'theoretical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'critically'>, 'critical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'fantastically'>, 'fantastic'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'mystically'>, 'mystical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'pornographically'>, 'pornographic'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'fully'>, 'full'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'jolly'>, 'jolly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'wholly'>, 'whole'>;
+}
+
+namespace transforms {
+    // >=2 positives per transform arm + collisions + boundary fall-through
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'nobly'>, 'noble'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'feebly'>, 'feeble'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'humbly'>, 'humble'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'logically'>, 'logical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'magically'>, 'magical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'tragically'>, 'tragical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'historically'>, 'historical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'classically'>, 'classical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'periodically'>, 'periodical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'graphically'>, 'graphical'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'publically'>, 'public'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'specifically'>, 'specific'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'terrifically'>, 'terrific'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'truly'>, 'true'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'unduly'>, 'undue'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'happily'>, 'happy'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'easily'>, 'easy'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'lazily'>, 'lazy'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'quickly'>, 'quick'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'slowly'>, 'slow'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'gladly'>, 'glad'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'bravely'>, 'brave'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'fly'>, 'fly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'ply'>, 'ply'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'sly'>, 'sly'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'ably'>, 'able'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'rely'>, 'rely'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'sky'>, 'sky'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'cat'>, 'cat'>;
+}
+
+namespace caseFolding {
+    // input folded through Lowercase<T>; output lowercase
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'QUICKLY'>, 'quick'>;
+    // @ts-expect-no-error
+    isAssignable<ToAdjective<'Idly'>, 'idle'>;
+}

--- a/libraries/typed-pluralizer/src/converter/to-adjective.ts
+++ b/libraries/typed-pluralizer/src/converter/to-adjective.ts
@@ -1,0 +1,58 @@
+// http://compromise.cool/website/browse/to_adjective.html
+//
+// Adverb -> adjective. Upstream `to_adjective(str)`: checks an 18-entry
+// irregular map first, then iterates 7 transform rules first-match-wins, then
+// falls through returning the input unchanged. Upstream never returns
+// null/undefined, so there is no `never` case here: an unmatched word converts
+// to itself (folded to lowercase). The `never` mapping convention — "upstream
+// returns null/undefined => the type resolves to never" — does not apply to
+// this file because to_adjective has no null/undefined return path.
+//
+// Accepted divergence: matching is case-insensitive via the `Lowercase<T>` fold
+// and output is always lowercase; upstream /i regexes preserve case.
+
+import { AnyOf, Letter, ReplaceEnding } from '../util';
+
+// Irregular adverb->adjective pairs (upstream `irregulars` object literal).
+type irregulars = {
+    idly: 'idle'; // 'idly': 'idle'
+    sporadically: 'sporadic'; // 'sporadically': 'sporadic'
+    basically: 'basic'; // 'basically': 'basic'
+    grammatically: 'grammatical'; // 'grammatically': 'grammatical'
+    alphabetically: 'alphabetical'; // 'alphabetically': 'alphabetical'
+    economically: 'economical'; // 'economically': 'economical'
+    conically: 'conical'; // 'conically': 'conical'
+    politically: 'political'; // 'politically': 'political'
+    vertically: 'vertical'; // 'vertically': 'vertical'
+    practically: 'practical'; // 'practically': 'practical'
+    theoretically: 'theoretical'; // 'theoretically': 'theoretical'
+    critically: 'critical'; // 'critically': 'critical'
+    fantastically: 'fantastic'; // 'fantastically': 'fantastic'
+    mystically: 'mystical'; // 'mystically': 'mystical'
+    pornographically: 'pornographic'; // 'pornographically': 'pornographic'
+    fully: 'full'; // 'fully': 'full'
+    jolly: 'jolly'; // 'jolly': 'jolly'
+    wholly: 'whole'; // 'wholly': 'whole'
+};
+
+export type ToAdjective<T extends string> = _ToAdjective<Lowercase<T>>;
+
+type _ToAdjective<T> =
+    // if (irregulars.hasOwnProperty(str)) return irregulars[str];
+    T extends keyof irregulars ? irregulars[T]
+    : // {'reg': /bly$/i, 'repl': 'ble'}
+    T extends `${string}bly` ? ReplaceEnding<T, 'bly', 'ble'>
+    : // {'reg': /gically$/i, 'repl': 'gical'}
+    T extends `${string}gically` ? ReplaceEnding<T, 'gically', 'gical'>
+    : // {'reg': /([rsdh])ically$/i, 'repl': '$1ical'}
+    T extends `${string}${AnyOf<'rsdh'>}ically` ? ReplaceEnding<T, 'ically', 'ical'>
+    : // {'reg': /ically$/i, 'repl': 'ic'}
+    T extends `${string}ically` ? ReplaceEnding<T, 'ically', 'ic'>
+    : // {'reg': /uly$/i, 'repl': 'ue'}
+    T extends `${string}uly` ? ReplaceEnding<T, 'uly', 'ue'>
+    : // {'reg': /ily$/i, 'repl': 'y'}
+    T extends `${string}ily` ? ReplaceEnding<T, 'ily', 'y'>
+    : // {'reg': /(.{3})ly$/i, 'repl': '$1'} — 3+ chars before `ly`, drop `ly`
+    T extends `${string}${Letter}${Letter}${Letter}ly` ? ReplaceEnding<T, 'ly', ''>
+    : // for-loop exhausted: return str (input unchanged, lowercased)
+        T;

--- a/libraries/typed-pluralizer/src/converter/to-noun.d.test.ts
+++ b/libraries/typed-pluralizer/src/converter/to-noun.d.test.ts
@@ -1,0 +1,126 @@
+import { ToNoun } from './to-noun';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// Generated from the verified converter dataset (oracle == type on every case).
+// Each assertion's expected literal is the empirically resolved ToNoun output.
+// '' inputs and no-conversion words resolve to `never`; asserted as such.
+
+namespace irregularMap {
+    // full irregular-map membership: every key asserted
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'clean'>, 'cleanliness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'naivety'>, 'naivety'>;
+}
+
+namespace emptyInput {
+    // !w => empty string upstream => no conversion => never
+    // @ts-expect-no-error
+    isAssignable<ToNoun<''>, never>;
+}
+
+namespace transforms {
+    // >=2 positives per transform arm + gates (space, w$, s$) + default
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'happy'>, 'happiness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'silly'>, 'silliness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'lovely'>, 'loveliness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'gentle'>, 'gentility'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'able'>, 'ability'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'noble'>, 'nobility'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'partial'>, 'party'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'special'>, 'specy'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'facial'>, 'facy'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'normal'>, 'normality'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'brutal'>, 'brutality'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'final'>, 'finality'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'acting'>, 'acting'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'meeting'>, 'meeting'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'waiting'>, 'waiting'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'caring'>, 'caring'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'boring'>, 'boring'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'staring'>, 'staring'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'climbing'>, 'climbingness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'rubbing'>, 'rubbingness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'sobbing'>, 'sobbingness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'closing'>, 'close'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'rising'>, 'rise'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'choosing'>, 'choose'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'moving'>, 'movment'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'feeling'>, 'feelment'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'meaning'>, 'meanment'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'careless'>, 'carelessness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'helpless'>, 'helplessness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'useless'>, 'uselessness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'famous'>, 'famousness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'nervous'>, 'nervousness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'jealous'>, 'jealousness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'gas'>, 'gas'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'bus'>, 'bus'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'this'>, 'this'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'cars'>, 'cars'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'hot dog'>, 'hot dog'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'ice cream'>, 'ice cream'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'slow'>, 'slow'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'follow'>, 'follow'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'yellow'>, 'yellow'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'kind'>, 'kindness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'bold'>, 'boldness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'hot'>, 'hotness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'red'>, 'redness'>;
+}
+
+namespace caseFolding {
+    // input folded through Lowercase<T>; output lowercase
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'HAPPY'>, 'happiness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'Clean'>, 'cleanliness'>;
+}

--- a/libraries/typed-pluralizer/src/converter/to-noun.d.test.ts
+++ b/libraries/typed-pluralizer/src/converter/to-noun.d.test.ts
@@ -115,6 +115,16 @@ namespace transforms {
     isAssignable<ToNoun<'hot'>, 'hotness'>;
     // @ts-expect-no-error
     isAssignable<ToNoun<'red'>, 'redness'>;
+    // final fallthrough is unconditional (`return w + 'ness'`): inputs whose
+    // lowercased form ends in a non-letter (digit/punctuation) still get `ness`.
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'ab3'>, 'ab3ness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'x9'>, 'x9ness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'a1'>, 'a1ness'>;
+    // @ts-expect-no-error
+    isAssignable<ToNoun<'x-'>, 'x-ness'>;
 }
 
 namespace caseFolding {

--- a/libraries/typed-pluralizer/src/converter/to-noun.ts
+++ b/libraries/typed-pluralizer/src/converter/to-noun.ts
@@ -1,0 +1,62 @@
+// http://compromise.cool/website/browse/to_noun.html
+//
+// Adjective/verb -> noun. Upstream `to_noun(w)`: returns '' for empty input,
+// then checks a 2-entry irregular map, then two early gates (contains a space;
+// ends in `w`), then iterates 11 transform rules first-match-wins, then a final
+// `/s$/` gate, then falls through appending `ness`.
+//
+// `never` mapping: upstream returns '' only for falsy (empty) input. Per the
+// "upstream returns null/undefined/'' (no conversion) => the type resolves to
+// never" convention, the empty-string input maps to `never` here. Every other
+// path returns a real string, so there are no other `never` cases.
+//
+// Accepted divergence: matching is case-insensitive via the `Lowercase<T>` fold
+// and output is always lowercase; upstream regexes are non-/i but only ever see
+// lowercase input, so behaviour is identical.
+
+import { Letter, ReplaceEnding } from '../util';
+
+// Irregular adjective/verb->noun pairs (upstream `irregulars` object literal).
+type irregulars = {
+    clean: 'cleanliness'; // 'clean': 'cleanliness'
+    naivety: 'naivety'; // 'naivety': 'naivety'
+};
+
+export type ToNoun<T extends string> = _ToNoun<Lowercase<T>>;
+
+type _ToNoun<T> =
+    // if (!w) return ''; — empty input has no conversion => never
+    T extends '' ? never
+    : // if (irregulars.hasOwnProperty(w)) return irregulars[w];
+    T extends keyof irregulars ? irregulars[T]
+    : // if (w.match(' ')) return w; — contains a space anywhere
+    T extends `${string} ${string}` ? T
+    : // if (w.match(/w$/)) return w;
+    T extends `${string}w` ? T
+    : // {'reg': /y$/, 'repl': 'iness'}
+    T extends `${string}y` ? ReplaceEnding<T, 'y', 'iness'>
+    : // {'reg': /le$/, 'repl': 'ility'}
+    T extends `${string}le` ? ReplaceEnding<T, 'le', 'ility'>
+    : // {'reg': /ial$/, 'repl': 'y'}
+    T extends `${string}ial` ? ReplaceEnding<T, 'ial', 'y'>
+    : // {'reg': /al$/, 'repl': 'ality'}
+    T extends `${string}al` ? ReplaceEnding<T, 'al', 'ality'>
+    : // {'reg': /ting$/, 'repl': 'ting'} — no-op
+    T extends `${string}ting` ? T
+    : // {'reg': /ring$/, 'repl': 'ring'} — no-op
+    T extends `${string}ring` ? T
+    : // {'reg': /bing$/, 'repl': 'bingness'}
+    T extends `${string}bing` ? ReplaceEnding<T, 'bing', 'bingness'>
+    : // {'reg': /sing$/, 'repl': 'se'}
+    T extends `${string}sing` ? ReplaceEnding<T, 'sing', 'se'>
+    : // {'reg': /ing$/, 'repl': 'ment'}
+    T extends `${string}ing` ? ReplaceEnding<T, 'ing', 'ment'>
+    : // {'reg': /ess$/, 'repl': 'essness'}
+    T extends `${string}ess` ? ReplaceEnding<T, 'ess', 'essness'>
+    : // {'reg': /ous$/, 'repl': 'ousness'}
+    T extends `${string}ous` ? ReplaceEnding<T, 'ous', 'ousness'>
+    : // if (w.match(/s$/)) return w;
+    T extends `${string}s` ? T
+    : // return w + 'ness';
+    T extends `${string}${Letter}` ? `${T}ness`
+    : T;

--- a/libraries/typed-pluralizer/src/converter/to-noun.ts
+++ b/libraries/typed-pluralizer/src/converter/to-noun.ts
@@ -14,7 +14,7 @@
 // and output is always lowercase; upstream regexes are non-/i but only ever see
 // lowercase input, so behaviour is identical.
 
-import { Letter, ReplaceEnding } from '../util';
+import { ReplaceEnding } from '../util';
 
 // Irregular adjective/verb->noun pairs (upstream `irregulars` object literal).
 type irregulars = {
@@ -24,7 +24,7 @@ type irregulars = {
 
 export type ToNoun<T extends string> = _ToNoun<Lowercase<T>>;
 
-type _ToNoun<T> =
+type _ToNoun<T extends string> =
     // if (!w) return ''; — empty input has no conversion => never
     T extends '' ? never
     : // if (irregulars.hasOwnProperty(w)) return irregulars[w];
@@ -57,6 +57,5 @@ type _ToNoun<T> =
     T extends `${string}ous` ? ReplaceEnding<T, 'ous', 'ousness'>
     : // if (w.match(/s$/)) return w;
     T extends `${string}s` ? T
-    : // return w + 'ness';
-    T extends `${string}${Letter}` ? `${T}ness`
-    : T;
+    : // return w + 'ness'; — unconditional append (matches upstream)
+        `${T}ness`;


### PR DESCRIPTION
Adds three type-level converter rules under `libraries/typed-pluralizer/src/converter/` (new directory, no barrel — export wiring is a later PR), each transcribed from the corresponding compromise source:

- **`to-adjective.ts`** (`ToAdjective<T>`) — adverb→adjective. 18-entry irregular map, then 7 transform rules first-match-wins, then falls through to the lowercased input. Upstream has no null/undefined return, so there is no `never` case here; documented at the top.
- **`to-noun.ts`** (`ToNoun<T>`) — adjective/verb→noun. Empty input → `never`, 2-entry irregular map, space and `w$` gates, 11 transform rules first-match-wins, trailing `s$` gate, then `+ness` default. Preserves the upstream `/ing$/`→`'ment'` quirk faithfully (`moving` → `movment`).
- **`to-actor.ts`** (`ToActor<T>`) — verb→actor noun. 12-word `dont` gate → `never`, 10-entry irregular map, 4 transform rules first-match-wins, then `+er` default. The `dont` gate precedes the irregular/transform checks, matching upstream short-circuit order (`try`/`bet`/`marry` resolve to `never`, not their transform outputs).

Each public type folds `Lowercase<T>` into a `_`-prefixed internal, mirroring `pluralization-rules.ts`/`to-infinitive.ts`. Irregular maps mirror the `irregular-verbs.ts` map style; the `dont` list is a named union. Every rule arm carries the upstream JS line / regex as an adjacent comment, and each file cites its compromise source URL. The "upstream null/undefined → `never`" mapping is documented at the top of each file.

## How verified

A node oracle replicates each upstream JS function exactly (iteration order, first-match short-circuit, dont-gate precedence, fallbacks — transcribed, not paraphrased). A curated dataset (full map/list membership + ≥2 positives per transform arm + boundary negatives + cross-arm collision probes + union first/last + fall-through words) is resolved to its actual type via the tsc sentinel-assignment probe against this branch's source.

**Result: 148 dataset cases + targeted edge probes (case-folding, rule-3 `[rsdh]ically` collisions, naive/naivety boundary, dont-beats-transform priority, empty-string `never`), oracle and types agree on every case, 0 divergences.** No TS-limitation workarounds were needed; the only divergence is the accepted one — matching is case-insensitive via the `Lowercase<T>` fold and output is always lowercase (upstream `/i` regexes preserve case).

Each file ships a `.d.test.ts` generated from the verified dataset: full membership for every irregular-map key and every `dont` word, ≥2 positives per transform arm, boundary negatives, fall-through words, and case-folding. All three test files pass a full strict `tsc --noEmit --strict` type-check.

No new `util` helpers were added — the existing `AnyOf` / `Letter` / `Vowel` / `ReplaceEnding` cover every arm.

`node common/scripts/install-run-rush.js build --to typed-pluralizer` passes clean.

### Note on the `.d.test.ts` build gate
Empirically, `heft build` does **not** type-check `*.d.test.ts` files — a deliberate hard type error inside one does not fail the build (confirmed against the existing `from-infinitive.d.test.ts` convention too; this is pre-existing repo behavior, not introduced here). The new test files are nonetheless correct under a standalone strict `tsc` check, so they serve as a regression gate the moment a real type-test task is wired up.
