### PR TITLE
feat(typed-pluralizer): add irregular-noun map with both directions

### DIFF
--- a/libraries/typed-pluralizer/src/pluralizer/irregular-nouns.d.test.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/irregular-nouns.d.test.ts
@@ -1,0 +1,270 @@
+import { PluralizeIrregular, SingularizeIrregular } from './irregular-nouns';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// Generated from blakeembrey/pluralize v8.0.0 irregular pairs. Every pair is
+// asserted in both directions (PluralizeIrregular single->plural,
+// SingularizeIrregular plural->single), plus never-controls for non-members.
+// This module is complete — no known-wrong cases.
+
+namespace pluralizeForward {
+    // singular -> plural, all 47 pairs.
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'i'>, 'we'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'me'>, 'us'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'he'>, 'they'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'she'>, 'they'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'them'>, 'them'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'myself'>, 'ourselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'yourself'>, 'yourselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'itself'>, 'themselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'herself'>, 'themselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'himself'>, 'themselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'themself'>, 'themselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'is'>, 'are'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'was'>, 'were'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'has'>, 'have'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'this'>, 'these'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'that'>, 'those'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'echo'>, 'echoes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'dingo'>, 'dingoes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'volcano'>, 'volcanoes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'tornado'>, 'tornadoes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'torpedo'>, 'torpedoes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'genus'>, 'genera'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'viscus'>, 'viscera'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'stigma'>, 'stigmata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'stoma'>, 'stomata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'dogma'>, 'dogmata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'lemma'>, 'lemmata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'schema'>, 'schemata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'anathema'>, 'anathemata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'ox'>, 'oxen'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'axe'>, 'axes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'die'>, 'dice'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'yes'>, 'yeses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'foot'>, 'feet'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'eave'>, 'eaves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'goose'>, 'geese'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'tooth'>, 'teeth'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'quiz'>, 'quizzes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'human'>, 'humans'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'proof'>, 'proofs'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'carve'>, 'carves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'valve'>, 'valves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'looey'>, 'looies'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'thief'>, 'thieves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'groove'>, 'grooves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'pickaxe'>, 'pickaxes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'passerby'>, 'passersby'>;
+}
+
+namespace singularizeInverse {
+    // plural -> singular, all 43 resolved inverse entries. Four plurals
+    // collide in the upstream inverse map; the last-written single wins:
+    //   'they'       <- he, she                            => 'she'
+    //   'themselves' <- itself, herself, himself, themself => 'themself'
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'we'>, 'i'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'us'>, 'me'>;
+    // collision winner (last write): they -> she
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'they'>, 'she'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'them'>, 'them'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'ourselves'>, 'myself'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'yourselves'>, 'yourself'>;
+    // collision winner (last write): themselves -> themself
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'themselves'>, 'themself'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'are'>, 'is'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'were'>, 'was'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'have'>, 'has'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'these'>, 'this'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'those'>, 'that'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'echoes'>, 'echo'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'dingoes'>, 'dingo'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'volcanoes'>, 'volcano'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'tornadoes'>, 'tornado'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'torpedoes'>, 'torpedo'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'genera'>, 'genus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'viscera'>, 'viscus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'stigmata'>, 'stigma'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'stomata'>, 'stoma'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'dogmata'>, 'dogma'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'lemmata'>, 'lemma'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'schemata'>, 'schema'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'anathemata'>, 'anathema'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'oxen'>, 'ox'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'axes'>, 'axe'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'dice'>, 'die'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'yeses'>, 'yes'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'feet'>, 'foot'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'eaves'>, 'eave'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'geese'>, 'goose'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'teeth'>, 'tooth'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'quizzes'>, 'quiz'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'humans'>, 'human'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'proofs'>, 'proof'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'carves'>, 'carve'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'valves'>, 'valve'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'looies'>, 'looey'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'thieves'>, 'thief'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'grooves'>, 'groove'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'pickaxes'>, 'pickaxe'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'passersby'>, 'passerby'>;
+}
+
+namespace collisionLosers {
+    // The singulars that LOST the inverse collision still pluralize forward
+    // (their single->plural entry is intact), but the plural singularizes
+    // back to the winner, not to them. These assert the asymmetry.
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'he'>, 'they'>;
+    // 'they' singularizes to the winner 'she', not back to 'he'.
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'they'>, 'she'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'itself'>, 'themselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'herself'>, 'themselves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'himself'>, 'themselves'>;
+    // 'themselves' singularizes to the winner 'themself'.
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'themselves'>, 'themself'>;
+}
+
+namespace caseFolding {
+    // Input is folded through Lowercase<T> before matching; output is lowercase.
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'OX'>, 'oxen'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'Goose'>, 'geese'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'OXEN'>, 'ox'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'Teeth'>, 'tooth'>;
+}
+
+namespace nonMembers {
+    // Non-members resolve to never in both directions.
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'cat'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'cat'>, never>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'dog'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'dog'>, never>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'house'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'house'>, never>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'book'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'book'>, never>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'running'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'running'>, never>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'xyzzy'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'xyzzy'>, never>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'foots'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'foots'>, never>;
+    // @ts-expect-no-error
+    isAssignable<PluralizeIrregular<'gooses'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizeIrregular<'gooses'>, never>;
+}

--- a/libraries/typed-pluralizer/src/pluralizer/irregular-nouns.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/irregular-nouns.ts
@@ -1,0 +1,121 @@
+// Irregular noun pairs transcribed from blakeembrey/pluralize v8.0.0
+// (https://github.com/plurals/pluralize), the `addIrregularRule(single, plural)`
+// list in pluralize.js. Generated from source — zero hand transcription.
+//
+// Upstream `addIrregularRule` lowercases both members and populates two maps:
+//   irregularSingles[single] = plural   (forward, singular -> plural)
+//   irregularPlurals[plural] = single   (inverse, plural -> singular)
+// Both are plain-object assignments, so on a key collision the LAST pair wins.
+// All 47 singles are distinct, but four plurals collide in the inverse map:
+//   'they'       <- he, she                    => resolves to 'she'
+//   'themselves' <- itself, herself, himself, themself => resolves to 'themself'
+// The inverse map below encodes those last-write winners (see inline notes).
+//
+// Accepted divergence from upstream: matching is case-insensitive (input is
+// folded through `Lowercase<T>`) and output is always lowercase; upstream's /i
+// regexes preserve case.
+
+// Forward direction: singular -> plural. 47 distinct keys.
+interface IrregularSingles {
+    i: 'we';
+    me: 'us';
+    he: 'they';
+    she: 'they';
+    them: 'them';
+    myself: 'ourselves';
+    yourself: 'yourselves';
+    itself: 'themselves';
+    herself: 'themselves';
+    himself: 'themselves';
+    themself: 'themselves';
+    is: 'are';
+    was: 'were';
+    has: 'have';
+    this: 'these';
+    that: 'those';
+    echo: 'echoes';
+    dingo: 'dingoes';
+    volcano: 'volcanoes';
+    tornado: 'tornadoes';
+    torpedo: 'torpedoes';
+    genus: 'genera';
+    viscus: 'viscera';
+    stigma: 'stigmata';
+    stoma: 'stomata';
+    dogma: 'dogmata';
+    lemma: 'lemmata';
+    schema: 'schemata';
+    anathema: 'anathemata';
+    ox: 'oxen';
+    axe: 'axes';
+    die: 'dice';
+    yes: 'yeses';
+    foot: 'feet';
+    eave: 'eaves';
+    goose: 'geese';
+    tooth: 'teeth';
+    quiz: 'quizzes';
+    human: 'humans';
+    proof: 'proofs';
+    carve: 'carves';
+    valve: 'valves';
+    looey: 'looies';
+    thief: 'thieves';
+    groove: 'grooves';
+    pickaxe: 'pickaxes';
+    passerby: 'passersby';
+}
+
+// Inverse direction: plural -> singular. 43 distinct keys (four plurals collide;
+// last-write-wins, matching the upstream object assignment).
+interface IrregularPlurals {
+    we: 'i';
+    us: 'me';
+    they: 'she'; // collision: he->they then she->they; she wins (last write)
+    them: 'them';
+    ourselves: 'myself';
+    yourselves: 'yourself';
+    themselves: 'themself'; // collision: itself/herself/himself/themself->themselves; themself wins (last write)
+    are: 'is';
+    were: 'was';
+    have: 'has';
+    these: 'this';
+    those: 'that';
+    echoes: 'echo';
+    dingoes: 'dingo';
+    volcanoes: 'volcano';
+    tornadoes: 'tornado';
+    torpedoes: 'torpedo';
+    genera: 'genus';
+    viscera: 'viscus';
+    stigmata: 'stigma';
+    stomata: 'stoma';
+    dogmata: 'dogma';
+    lemmata: 'lemma';
+    schemata: 'schema';
+    anathemata: 'anathema';
+    oxen: 'ox';
+    axes: 'axe';
+    dice: 'die';
+    yeses: 'yes';
+    feet: 'foot';
+    eaves: 'eave';
+    geese: 'goose';
+    teeth: 'tooth';
+    quizzes: 'quiz';
+    humans: 'human';
+    proofs: 'proof';
+    carves: 'carve';
+    valves: 'valve';
+    looies: 'looey';
+    thieves: 'thief';
+    grooves: 'groove';
+    pickaxes: 'pickaxe';
+    passersby: 'passerby';
+}
+
+export type PluralizeIrregular<T extends string> =
+    Lowercase<T> extends keyof IrregularSingles ? IrregularSingles[Lowercase<T>] : never;
+
+export type SingularizeIrregular<T extends string> =
+    Lowercase<T> extends keyof IrregularPlurals ? IrregularPlurals[Lowercase<T>] : never;


### PR DESCRIPTION
## What

Adds `libraries/typed-pluralizer/src/pluralizer/irregular-nouns.ts` — a map-shaped, both-directions irregular-noun table extracted mechanically from blakeembrey/pluralize v8.0.0 (`addIrregularRule(single, plural)` list in `pluralize.js`).

- **`IrregularSingles`** (singular → plural, 47 distinct keys) and **`IrregularPlurals`** (plural → singular, 43 keys) replicate the upstream `irregularSingles` / `irregularPlurals` object derivation. `addIrregularRule` lowercases both members and assigns into plain objects, so on a key collision the **last pair wins**.
- All 47 singles are distinct. Four plurals collide in the inverse map; last-write-wins is preserved and documented inline:
  - `'they'` ← `he`, `she` ⇒ resolves to **`'she'`**
  - `'themselves'` ← `itself`, `herself`, `himself`, `themself` ⇒ resolves to **`'themself'`**
- **`PluralizeIrregular<T>`** / **`SingularizeIrregular<T>`** fold input through `Lowercase<T>` and resolve non-members to `never`.
- Pair data and the both-direction membership tests are **generated from source by script** — zero hand transcription.

No new `util` helper was needed (plain `keyof` map lookup). No `index.ts` barrel touched (export wiring is a later PR). `irregular-rules.ts` and `irregular-verbs.ts` were not modified.

## How verified

A node oracle replicates the upstream `addIrregularRule` derivation exactly (lowercase both, last-write-wins into the two objects). Each word's actual resolved type was read out of `tsc --strict` via the sentinel-assignment probe (`const v: Fn<'word'> = S` where `S: {__s:true}`, parsing the TS2322 "not assignable to type ..." literal).

- **Oracle size:** 47 source pairs → 47 forward entries + 43 inverse entries.
- **Dataset:** 47 forward asserts + 43 inverse asserts + 16 non-member `never`-controls + 3 case-fold probes = **109 cases**.
- **Agreement:** **109/109** oracle-vs-type agree.
- **Documented divergence:** the single accepted one — matching is case-insensitive (input folded through `Lowercase<T>`) and output is always lowercase; upstream's `/i` regexes preserve case. No TS-limitation divergences.

The `.d.test.ts` encodes all 109 cases as `@ts-expect-no-error` assertions (no known-wrong cases), plus a `collisionLosers` namespace asserting the forward/inverse asymmetry for the collision losers. `rush build --to typed-pluralizer` passes clean.

## Overlap with existing `irregular-rules.ts` (for the later composition PR)

The standalone `irregular-rules.ts` covers the **same upstream list**, so **all 47 singular keys overlap**:

`i, me, he, she, them, myself, yourself, itself, herself, himself, themself, is, was, has, this, that, echo, dingo, volcano, tornado, torpedo, genus, viscus, stigma, stoma, dogma, lemma, schema, anathema, ox, axe, die, yes, foot, eave, goose, tooth, quiz, human, proof, carve, valve, looey, thief, groove, pickaxe, passerby`

One **value divergence** between the two:

- `passerby` → old `irregular-rules.ts` emits `'passerby'` (a transcription bug — passthrough); this from-source module correctly emits `'passersby'`.

Reconciliation (which table wins, and fixing the `passerby`/`passersby` bug) happens in the later composition PR, per the task plan. This PR does not touch `irregular-rules.ts`.
