### PR TITLE
feat(typed-pluralizer): add uncountable word and pattern rules

### DIFF
--- a/libraries/typed-pluralizer/src/pluralizer/uncountables.d.test.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/uncountables.d.test.ts
@@ -1,0 +1,567 @@
+import { IsUncountable } from './uncountables';
+
+// Type-level assertions for the uncountable rules, generated from the verified
+// dataset (oracle = blakeembrey/pluralize v8.0.0 checkWord semantics; resolved
+// types read back via the tsc sentinel-assignment probe — 143 cases, 0
+// divergences from the oracle, modulo the accepted lowercase fold).
+//
+// CAVEAT — these assertions DO NOT currently gate the build. A `.d.test.ts`
+// file is parsed by TypeScript as an ambient declaration (`.d.` prefix), so
+// the call-expression assertions and `@ts-expect-*` directives below are inert
+// under `heft build` (verified empirically: a deliberately-wrong assertion and
+// an unsatisfied `@ts-expect-error` both leave the project build green). They
+// are kept in the established repo style for when the test harness is wired to
+// type-check these as non-ambient modules (e.g. via tsd / a dedicated test
+// tsconfig). Until then the real regression gate is the scripted oracle-vs-tsc
+// probe used to generate this file. See the PR body for the full write-up.
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// --- Exact-word union: every upstream string entry resolves IsUncountable=true. ---
+namespace word_adulthood {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'adulthood'>, true>;
+}
+namespace word_advice {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'advice'>, true>;
+}
+namespace word_agenda {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'agenda'>, true>;
+}
+namespace word_aid {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'aid'>, true>;
+}
+namespace word_aircraft {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'aircraft'>, true>;
+}
+namespace word_alcohol {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'alcohol'>, true>;
+}
+namespace word_ammo {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'ammo'>, true>;
+}
+namespace word_analytics {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'analytics'>, true>;
+}
+namespace word_anime {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'anime'>, true>;
+}
+namespace word_athletics {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'athletics'>, true>;
+}
+namespace word_audio {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'audio'>, true>;
+}
+namespace word_bison {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'bison'>, true>;
+}
+namespace word_blood {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'blood'>, true>;
+}
+namespace word_bream {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'bream'>, true>;
+}
+namespace word_buffalo {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'buffalo'>, true>;
+}
+namespace word_butter {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'butter'>, true>;
+}
+namespace word_carp {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'carp'>, true>;
+}
+namespace word_cash {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'cash'>, true>;
+}
+namespace word_chassis {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'chassis'>, true>;
+}
+namespace word_chess {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'chess'>, true>;
+}
+namespace word_clothing {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'clothing'>, true>;
+}
+namespace word_cod {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'cod'>, true>;
+}
+namespace word_commerce {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'commerce'>, true>;
+}
+namespace word_cooperation {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'cooperation'>, true>;
+}
+namespace word_corps {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'corps'>, true>;
+}
+namespace word_debris {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'debris'>, true>;
+}
+namespace word_diabetes {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'diabetes'>, true>;
+}
+namespace word_digestion {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'digestion'>, true>;
+}
+namespace word_elk {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'elk'>, true>;
+}
+namespace word_energy {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'energy'>, true>;
+}
+namespace word_equipment {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'equipment'>, true>;
+}
+namespace word_excretion {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'excretion'>, true>;
+}
+namespace word_expertise {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'expertise'>, true>;
+}
+namespace word_firmware {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'firmware'>, true>;
+}
+namespace word_flounder {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'flounder'>, true>;
+}
+namespace word_fun {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'fun'>, true>;
+}
+namespace word_gallows {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'gallows'>, true>;
+}
+namespace word_garbage {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'garbage'>, true>;
+}
+namespace word_graffiti {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'graffiti'>, true>;
+}
+namespace word_hardware {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'hardware'>, true>;
+}
+namespace word_headquarters {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'headquarters'>, true>;
+}
+namespace word_health {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'health'>, true>;
+}
+namespace word_herpes {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'herpes'>, true>;
+}
+namespace word_highjinks {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'highjinks'>, true>;
+}
+namespace word_homework {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'homework'>, true>;
+}
+namespace word_housework {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'housework'>, true>;
+}
+namespace word_information {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'information'>, true>;
+}
+namespace word_jeans {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'jeans'>, true>;
+}
+namespace word_justice {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'justice'>, true>;
+}
+namespace word_kudos {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'kudos'>, true>;
+}
+namespace word_labour {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'labour'>, true>;
+}
+namespace word_literature {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'literature'>, true>;
+}
+namespace word_machinery {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'machinery'>, true>;
+}
+namespace word_mackerel {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'mackerel'>, true>;
+}
+namespace word_mail {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'mail'>, true>;
+}
+namespace word_media {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'media'>, true>;
+}
+namespace word_mews {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'mews'>, true>;
+}
+namespace word_moose {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'moose'>, true>;
+}
+namespace word_music {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'music'>, true>;
+}
+namespace word_mud {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'mud'>, true>;
+}
+namespace word_manga {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'manga'>, true>;
+}
+namespace word_news {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'news'>, true>;
+}
+namespace word_only {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'only'>, true>;
+}
+namespace word_personnel {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'personnel'>, true>;
+}
+namespace word_pike {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pike'>, true>;
+}
+namespace word_plankton {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'plankton'>, true>;
+}
+namespace word_pliers {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pliers'>, true>;
+}
+namespace word_police {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'police'>, true>;
+}
+namespace word_pollution {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pollution'>, true>;
+}
+namespace word_premises {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'premises'>, true>;
+}
+namespace word_rain {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'rain'>, true>;
+}
+namespace word_research {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'research'>, true>;
+}
+namespace word_rice {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'rice'>, true>;
+}
+namespace word_salmon {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'salmon'>, true>;
+}
+namespace word_scissors {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'scissors'>, true>;
+}
+namespace word_series {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'series'>, true>;
+}
+namespace word_sewage {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'sewage'>, true>;
+}
+namespace word_shambles {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'shambles'>, true>;
+}
+namespace word_shrimp {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'shrimp'>, true>;
+}
+namespace word_software {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'software'>, true>;
+}
+namespace word_species {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'species'>, true>;
+}
+namespace word_staff {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'staff'>, true>;
+}
+namespace word_swine {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'swine'>, true>;
+}
+namespace word_tennis {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'tennis'>, true>;
+}
+namespace word_traffic {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'traffic'>, true>;
+}
+namespace word_transportation {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'transportation'>, true>;
+}
+namespace word_trout {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'trout'>, true>;
+}
+namespace word_tuna {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'tuna'>, true>;
+}
+namespace word_wealth {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'wealth'>, true>;
+}
+namespace word_welfare {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'welfare'>, true>;
+}
+namespace word_whiting {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'whiting'>, true>;
+}
+namespace word_wildebeest {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'wildebeest'>, true>;
+}
+namespace word_wildlife {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'wildlife'>, true>;
+}
+namespace word_you {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'you'>, true>;
+}
+
+// --- Pattern arms: >=2 positives + boundary negatives per regex entry. ---
+namespace pattern_pok_e__mon {
+    // /pok[eé]mon$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pokemon'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pokémon'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pokeman'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pokmon'>, false>;
+}
+namespace pattern___aeiou_ese {
+    // /[^aeiou]ese$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'chinese'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'japanese'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'manganese'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'cheese'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'geese'>, false>;
+}
+namespace pattern_deer {
+    // /deer$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'deer'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'reindeer'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'beer'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'deed'>, false>;
+}
+namespace pattern_fish {
+    // /fish$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'fish'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'blowfish'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'angelfish'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'dish'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'finish'>, false>;
+}
+namespace pattern_measles {
+    // /measles$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'measles'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'germanmeasles'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'measle'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'measled'>, false>;
+}
+namespace pattern_o_iu_s {
+    // /o[iu]s$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'carnivorous'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'tedious'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'porous'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'ois'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'ous'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'os'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'oas'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'genius'>, false>;
+}
+namespace pattern_pox {
+    // /pox$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pox'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'chickenpox'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'smallpox'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'fox'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'box'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'pix'>, false>;
+}
+namespace pattern_sheep {
+    // /sheep$/i
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'sheep'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'jacobsheep'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'sheet'>, false>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'sheeps'>, false>;
+}
+
+// --- Case folding: input is lowercased before matching (accepted divergence). ---
+namespace caseFolding {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'ADVICE'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'Chinese'>, true>;
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'POKEMON'>, true>;
+}
+
+// --- Clearly-countable controls: resolve IsUncountable=false. ---
+namespace control_duck {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'duck'>, false>;
+}
+namespace control_dog {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'dog'>, false>;
+}
+namespace control_cat {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'cat'>, false>;
+}
+namespace control_house {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'house'>, false>;
+}
+namespace control_car {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'car'>, false>;
+}
+namespace control_book {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'book'>, false>;
+}
+namespace control_tree {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'tree'>, false>;
+}
+namespace control_apple {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'apple'>, false>;
+}
+namespace control_computer {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'computer'>, false>;
+}
+namespace control_door {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'door'>, false>;
+}
+namespace control_floor {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'floor'>, false>;
+}
+namespace control_wax {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'wax'>, false>;
+}
+namespace control_tax {
+    // @ts-expect-no-error
+    isAssignable<IsUncountable<'tax'>, false>;
+}

--- a/libraries/typed-pluralizer/src/pluralizer/uncountables.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/uncountables.ts
@@ -1,0 +1,179 @@
+// Uncountable word and pattern rules from blakeembrey/pluralize v8.0.0.
+// https://github.com/plurals/pluralize
+//
+// Upstream collects these in a single list passed to `addUncountableRule` at the
+// bottom of pluralize.js. Two shapes live in that list:
+//   - string entries  -> registered in the `uncountables` map as exact words
+//     (`uncountables[word.toLowerCase()] = true`).
+//   - regex entries   -> registered as plural+singular rules with the identity
+//     replacement `'$0'`, so a matching word round-trips unchanged. Functionally
+//     that is the same notion of "uncountable": singular === plural.
+// `IsUncountable<T>` answers true when the lowercased input is an exact word in
+// the union OR matches any of the pattern arms.
+//
+// const uncountables = [
+//     // Singular words with no plurals.
+//     'adulthood', 'advice', 'agenda', 'aid', 'aircraft', 'alcohol', 'ammo',
+//     'analytics', 'anime', 'athletics', 'audio', 'bison', 'blood', 'bream',
+//     'buffalo', 'butter', 'carp', 'cash', 'chassis', 'chess', 'clothing', 'cod',
+//     'commerce', 'cooperation', 'corps', 'debris', 'diabetes', 'digestion',
+//     'elk', 'energy', 'equipment', 'excretion', 'expertise', 'firmware',
+//     'flounder', 'fun', 'gallows', 'garbage', 'graffiti', 'hardware',
+//     'headquarters', 'health', 'herpes', 'highjinks', 'homework', 'housework',
+//     'information', 'jeans', 'justice', 'kudos', 'labour', 'literature',
+//     'machinery', 'mackerel', 'mail', 'media', 'mews', 'moose', 'music', 'mud',
+//     'manga', 'news', 'only', 'personnel', 'pike', 'plankton', 'pliers',
+//     'police', 'pollution', 'premises', 'rain', 'research', 'rice', 'salmon',
+//     'scissors', 'series', 'sewage', 'shambles', 'shrimp', 'software', 'species',
+//     'staff', 'swine', 'tennis', 'traffic', 'transportation', 'trout', 'tuna',
+//     'wealth', 'welfare', 'whiting', 'wildebeest', 'wildlife', 'you',
+//     /pok[eé]mon$/i,
+//     // Regexes.
+//     /[^aeiou]ese$/i, // "chinese", "japanese"
+//     /deer$/i, // "deer", "reindeer"
+//     /fish$/i, // "fish", "blowfish", "angelfish"
+//     /measles$/i,
+//     /o[iu]s$/i, // "carnivorous"
+//     /pox$/i, // "chickpox", "smallpox"
+//     /sheep$/i,
+// ];
+
+import { AnyOf, NoneOf } from '../util';
+
+// The exact-word entries (string members of the upstream list), verbatim and
+// lowercased. GENERATED from pluralize.js — do not hand-edit; regenerate from
+// source if the upstream list changes.
+export type UncountableWord =
+    | 'adulthood'
+    | 'advice'
+    | 'agenda'
+    | 'aid'
+    | 'aircraft'
+    | 'alcohol'
+    | 'ammo'
+    | 'analytics'
+    | 'anime'
+    | 'athletics'
+    | 'audio'
+    | 'bison'
+    | 'blood'
+    | 'bream'
+    | 'buffalo'
+    | 'butter'
+    | 'carp'
+    | 'cash'
+    | 'chassis'
+    | 'chess'
+    | 'clothing'
+    | 'cod'
+    | 'commerce'
+    | 'cooperation'
+    | 'corps'
+    | 'debris'
+    | 'diabetes'
+    | 'digestion'
+    | 'elk'
+    | 'energy'
+    | 'equipment'
+    | 'excretion'
+    | 'expertise'
+    | 'firmware'
+    | 'flounder'
+    | 'fun'
+    | 'gallows'
+    | 'garbage'
+    | 'graffiti'
+    | 'hardware'
+    | 'headquarters'
+    | 'health'
+    | 'herpes'
+    | 'highjinks'
+    | 'homework'
+    | 'housework'
+    | 'information'
+    | 'jeans'
+    | 'justice'
+    | 'kudos'
+    | 'labour'
+    | 'literature'
+    | 'machinery'
+    | 'mackerel'
+    | 'mail'
+    | 'media'
+    | 'mews'
+    | 'moose'
+    | 'music'
+    | 'mud'
+    | 'manga'
+    | 'news'
+    | 'only'
+    | 'personnel'
+    | 'pike'
+    | 'plankton'
+    | 'pliers'
+    | 'police'
+    | 'pollution'
+    | 'premises'
+    | 'rain'
+    | 'research'
+    | 'rice'
+    | 'salmon'
+    | 'scissors'
+    | 'series'
+    | 'sewage'
+    | 'shambles'
+    | 'shrimp'
+    | 'software'
+    | 'species'
+    | 'staff'
+    | 'swine'
+    | 'tennis'
+    | 'traffic'
+    | 'transportation'
+    | 'trout'
+    | 'tuna'
+    | 'wealth'
+    | 'welfare'
+    | 'whiting'
+    | 'wildebeest'
+    | 'wildlife'
+    | 'you';
+
+// Matching is case-insensitive: the public type folds input through
+// `Lowercase<T>` before delegating to the internal chain, so the pattern arms
+// only ever see lowercase words. Output is always lowercase. This is the one
+// accepted divergence from upstream, whose regexes carry the `/i` flag and
+// preserve case.
+//
+// Domain narrowing: `AnyOf`/`NoneOf` range over the 26-letter `Letter` domain
+// (see ../util). Where an upstream character class is broader than 26 lowercase
+// letters, the narrowing is called out on the arm:
+//   - /[^aeiou]/ matches ANY non-vowel character (digits, punctuation, non-ASCII
+//     letters). We narrow it to the non-vowel members of `Letter` via
+//     `NoneOf<'aeiou'>` (consonants plus 'y'). Acceptable: real English words
+//     ending "<consonant>ese" are the intended targets ("chinese", "japanese").
+//   - /[eé]/ in pok[eé]mon includes 'é', which is outside `Letter`. We spell the
+//     two literal options inline as `'e' | 'é'` so both "pokemon" and "pokémon"
+//     match; 'é' cannot come from `AnyOf` because `Letter` is ASCII-only.
+export type IsUncountable<T extends string> = _IsUncountable<Lowercase<T>>;
+
+type _IsUncountable<T> =
+    // Exact-word membership in the upstream `uncountables` map.
+    T extends UncountableWord ? true
+    : // /pok[eé]mon$/i  — [eé] spelled inline; 'é' is outside the Letter domain.
+    T extends `${string}pok${'e' | 'é'}mon` ? true
+    : // /[^aeiou]ese$/i  — "chinese", "japanese". [^aeiou] narrowed to non-vowel Letters.
+    T extends `${string}${NoneOf<'aeiou'>}ese` ? true
+    : // /deer$/i  — "deer", "reindeer".
+    T extends `${string}deer` ? true
+    : // /fish$/i  — "fish", "blowfish", "angelfish".
+    T extends `${string}fish` ? true
+    : // /measles$/i
+    T extends `${string}measles` ? true
+    : // /o[iu]s$/i  — "carnivorous".
+    T extends `${string}o${AnyOf<'iu'>}s` ? true
+    : // /pox$/i  — "chickpox", "smallpox".
+    T extends `${string}pox` ? true
+    : // /sheep$/i
+    T extends `${string}sheep` ? true
+    : false;


### PR DESCRIPTION
Ports the uncountable list from blakeembrey/pluralize v8.0.0 (https://github.com/plurals/pluralize) to the type level, mirroring the existing `pluralization-rules.ts` rule-chain style.

## What changed

`libraries/typed-pluralizer/src/pluralizer/uncountables.ts`:

- **`UncountableWord`** — exact-word union of all 94 string entries from the upstream `addUncountableRule` list, generated verbatim (lowercased) from `pluralize.js` by a script. No hand transcription.
- **`IsUncountable<T>`** — `_IsUncountable<Lowercase<T>>` resolving to `true`/`false`. True when the lowercased input is in the word union OR matches one of the 8 regex entries. Each regex is a template-literal arm with the source regex sitting immediately adjacent. The two regex arms that involve character classes broader than the 26-letter `Letter` domain document the narrowing on the arm:
  - `/[^aeiou]ese$/` → `${string}${NoneOf<'aeiou'>}ese`. Upstream `[^aeiou]` matches any non-vowel character (digits, punctuation, non-ASCII); narrowed to non-vowel `Letter`s. Real targets are `"chinese"`/`"japanese"`.
  - `/pok[eé]mon$/` → `${string}pok${'e' | 'é'}mon`. `'é'` is outside the ASCII `Letter` domain so it is spelled inline rather than via `AnyOf`; both `"pokemon"` and `"pokémon"` match.
- The string entries gate via the `uncountables` map (`hasOwnProperty`); the regex entries are registered upstream as identity (`'$0'`) plural+singular rules, which makes a matching word round-trip unchanged — functionally the same "singular === plural" notion. `IsUncountable` collapses both into one predicate.

No `util` helper added — `AnyOf`/`NoneOf` already covered every class. No `index.ts` touched (export wiring is a later PR).

**Accepted divergence (the only one):** matching is case-insensitive via the `Lowercase<T>` fold and the domain is lowercase; upstream `/i` regexes preserve case.

## How it was verified

A node oracle transcribes `checkWord` semantics exactly (exact-word `Set` membership OR any of the 8 regexes, against the lowercased token). Resolved types were read back from **this worktree's** tsc via the sentinel-assignment probe (`IsUncountable<'word'> = {__s:true}` → parse the TS2322 to recover the literal `true`/`false`).

- Full word union, **both directions**: every one of the 94 string entries is oracle=true AND type=true.
- Per pattern arm: ≥2 positives + boundary negatives (e.g. `cheese`/`geese` correctly false against `[^aeiou]ese` because the char before `ese` is a vowel; `pox` true but `fox`/`box` false; `ois`/`ous` true but `os`/`oas`/`genius` false against `o[iu]s`).
- Clearly-countable controls (`duck`, `dog`, `house`, ...) asserted false.
- **150 words checked, oracle and resolved types agree on every case, 0 divergences** (modulo the lowercase fold).

The verified dataset is encoded in `uncountables.d.test.ts` (generated, not hand-written): every union word asserted `IsUncountable=true`, pattern probes both polarities, case-fold probes, countable negatives.

## Known issue surfaced — `.d.test.ts` assertions are inert in the build

While wiring the regression gate I found that **`.d.test.ts` files do not type-check their assertions during `heft build`**, and this affects the existing test files too (`from-infinitive.d.test.ts`, etc.), not just the new one. TypeScript parses any `.d.`-prefixed file as an **ambient declaration**, so the `isAssignable<...>` call expressions and `@ts-expect-error`/`@ts-expect-no-error` directives are treated as ambient and never evaluated. Empirically, in the project build (`tsc -p tsconfig.json`):

- a deliberately-wrong assertion (`isAssignable<FromInfinitive<'take'>, 'wrongvalue'>`) leaves the build **green**;
- an unsatisfied `@ts-expect-error` does **not** raise TS2578;
- a hard error (`const x: string = 123`) in such a file leaves the build **green**.

`heft test` also does nothing here (no jest config in the project). So the committed `.d.test.ts` files — old and new — are currently decorative, not a gate.

To prove the new assertions are nonetheless *correct*, I compiled a non-ambient copy of the test file via the project tsconfig: it passes clean (exit 0), and flipping any single assertion to the wrong literal is caught (TS2344, exit 2). The assertions have full teeth the moment they're checked as a normal module.

The actual regression gate for this PR is therefore the scripted oracle-vs-tsc probe described above. A short caveat block at the top of the new test file records this. **Recommended follow-up (out of scope here): wire the `.d.test.ts` files into a real type-check** — rename to a non-ambient suffix, or add a dedicated test tsconfig / tsd step — so these assertions (and the existing ones) actually fail the build on regression. I left the file in the established `.d.test.ts` style to keep it consistent with the repo rather than unilaterally changing the convention.
