### PR TITLE
feat(typed-pluralizer): add singularization rule set

### DIFF
--- a/libraries/typed-pluralizer/src/pluralizer/singularization-rules.d.test.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/singularization-rules.d.test.ts
@@ -1,0 +1,423 @@
+import { SingularizationRules } from './singularization-rules';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// Coverage for the singularization rule set, grouped by rule arm. Every case was
+// verified against a node oracle replicating blakeembrey/pluralize v8.0.0
+// `sanitizeWord` over the `singularRules` array (rules layer only). Oracle and
+// type agree on every case, so all assertions are @ts-expect-no-error.
+
+namespace menRule {
+    // [/men$/i, "man"] — highest priority
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'men'>, 'man'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'women'>, 'woman'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'omen'>, 'oman'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'specimen'>, 'speciman'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'acumen'>, 'acuman'>;
+}
+
+namespace eauxRule {
+    // [/(eau)x?$/i, "$1"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'bureaux'>, 'bureau'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'tableaux'>, 'tableau'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'chateaux'>, 'chateau'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'eaux'>, 'eau'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'eau'>, 'eau'>;
+}
+
+namespace childrenRule {
+    // [/(child)ren$/i, "$1"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'children'>, 'child'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'grandchildren'>, 'grandchild'>;
+}
+
+namespace personRule {
+    // [/(pe)(rson|ople)$/i, "$1rson"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'people'>, 'person'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'salespeople'>, 'salesperson'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'person'>, 'person'>;
+}
+
+namespace matrAppendIcesRule {
+    // [/(matr|append)ices$/i, "$1ix"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'matrices'>, 'matrix'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'appendices'>, 'appendix'>;
+}
+
+namespace codMurIcesRule {
+    // [/(cod|mur|sil|vert|ind)ices$/i, "$1ex"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'codices'>, 'codex'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'murices'>, 'murex'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'silices'>, 'silex'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'vertices'>, 'vertex'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'indices'>, 'index'>;
+}
+
+namespace alumnAeRule {
+    // [/(alumn|alg|vertebr)ae$/i, "$1a"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'alumnae'>, 'alumna'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'algae'>, 'alga'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'vertebrae'>, 'vertebra'>;
+}
+
+namespace onRule {
+    // [/(apheli|…|automat)a$/i, "$1on"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'aphelia'>, 'aphelion'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'phenomena'>, 'phenomenon'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'criteria'>, 'criterion'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'organa'>, 'organon'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'automata'>, 'automaton'>;
+}
+
+namespace umRule {
+    // [/(agend|…|quor)a$/i, "$1um"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'data'>, 'datum'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'agenda'>, 'agendum'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'addenda'>, 'addendum'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'bacteria'>, 'bacterium'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'curricula'>, 'curriculum'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'ova'>, 'ovum'>;
+}
+
+namespace usRule {
+    // [/(alumn|…|strat)(?:us|i)$/i, "$1us"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'alumni'>, 'alumnus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'cacti'>, 'cactus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'foci'>, 'focus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'radii'>, 'radius'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'syllabi'>, 'syllabus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'fungi'>, 'fungus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'nuclei'>, 'nucleus'>;
+}
+
+namespace testRule {
+    // [/(test)(?:is|es)$/i, "$1is"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'testis'>, 'testis'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'testes'>, 'testis'>;
+}
+
+namespace movieRule {
+    // [/(movie|twelve|abuse|e[mn]u)s$/i, "$1"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'movies'>, 'movie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'twelves'>, 'twelve'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'abuses'>, 'abuse'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'emus'>, 'emu'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'menus'>, 'menu'>;
+}
+
+namespace sisRule {
+    // [/(analy|…|ne)(?:sis|ses)$/i, "$1sis"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'analyses'>, 'analysis'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'crises'>, 'crisis'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'theses'>, 'thesis'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'diagnoses'>, 'diagnosis'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'emphases'>, 'emphasis'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'synopses'>, 'synopsis'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'parentheses'>, 'parenthesis'>;
+}
+
+namespace esRule {
+    // [/(x|ch|ss|sh|zz|tto|go|cho|alias|[^aou]us|t[lm]as|gas|(?:her|at|gr)o|[aeiou]ris)(?:es)?$/i, "$1"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'boxes'>, 'box'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'box'>, 'box'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'churches'>, 'church'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'glasses'>, 'glass'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'dishes'>, 'dish'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'buzzes'>, 'buzz'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'echo'>, 'echo'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'aliases'>, 'alias'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'campuses'>, 'campus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'buses'>, 'bus'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'atlases'>, 'atlas'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'gases'>, 'gas'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'irises'>, 'iris'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'heroes'>, 'hero'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'potatoes'>, 'potato'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'matrixes'>, 'matrix'>;
+}
+
+namespace seraphimRule {
+    // [/(seraph|cherub)im$/i, "$1"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'seraphim'>, 'seraph'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'cherubim'>, 'cherub'>;
+}
+
+namespace miceRule {
+    // [/\b((?:tit)?m|l)ice$/i, "$1ouse"] — \b-anchored
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'mice'>, 'mouse'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'lice'>, 'louse'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'titmice'>, 'titmouse'>;
+}
+
+namespace moniesRule {
+    // [/\b(mon|smil)ies$/i, "$1ey"] — \b-anchored
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'monies'>, 'money'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'smilies'>, 'smiley'>;
+}
+
+namespace ieRule {
+    // [/\b([pl]|zomb|(?:neck|cross)?t|coll|faer|food|gen|goon|group|lass|talk|goal|cut)ies$/i, "$1ie"] — \b-anchored
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'zombies'>, 'zombie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'pies'>, 'pie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'lies'>, 'lie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'ties'>, 'tie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'neckties'>, 'necktie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'crossties'>, 'crosstie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'collies'>, 'collie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'faeries'>, 'faerie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'foodies'>, 'foodie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'genies'>, 'genie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'goonies'>, 'goonie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'groupies'>, 'groupie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'lassies'>, 'lassie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'talkies'>, 'talkie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'goalies'>, 'goalie'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'cuties'>, 'cutie'>;
+}
+
+namespace iesYRule {
+    // [/ies$/i, "y"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'colonies'>, 'colony'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'bodies'>, 'body'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'cities'>, 'city'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'ladies'>, 'lady'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'bowties'>, 'bowty'>;
+}
+
+namespace vesFRule {
+    // [/(ar|(?:wo|[ae])l|[eo][ao])ves$/i, "$1f"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'wolves'>, 'wolf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'shelves'>, 'shelf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'loaves'>, 'loaf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'halves'>, 'half'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'elves'>, 'elf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'selves'>, 'self'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'calves'>, 'calf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'leaves'>, 'leaf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'wharves'>, 'wharf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'scarves'>, 'scarf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'dwarves'>, 'dwarf'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'themselves'>, 'themself'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'ourselves'>, 'ourself'>;
+}
+
+namespace vesFeRule {
+    // [/(wi|kni|(?:after|half|high|low|mid|non|night|[^\w]|^)li)ves$/i, "$1fe"]
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'wives'>, 'wife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'knives'>, 'knife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'lives'>, 'life'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'afterlives'>, 'afterlife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'halflives'>, 'halflife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'midlives'>, 'midlife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'nightlives'>, 'nightlife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'lowlives'>, 'lowlife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'nonlives'>, 'nonlife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'highlives'>, 'highlife'>;
+}
+
+namespace sStripRule {
+    // [/s$/i, ""] — lowest priority fall-back
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'cats'>, 'cat'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'houses'>, 'house'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'dogs'>, 'dog'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'thieves'>, 'thieve'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'dives'>, 'dive'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'gives'>, 'give'>;
+}
+
+namespace collisionProbes {
+    // Words that resemble a higher rule but resolve elsewhere.
+    // rule 5 is \b-anchored, so the inner `zomb` does not match
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'azombies'>, 'azomby'>;
+    // rule 5 \b-anchored; falls to /ies$/
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'apies'>, 'apy'>;
+    // rule 2 needs `kni` immediately before `ves`
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'kniives'>, 'kniive'>;
+    // rule 2 `li` branch only fires after the listed prefixes / start
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'gaslives'>, 'gaslive'>;
+    // same — `i` is not a listed prefix
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'ilives'>, 'ilive'>;
+    // not in the cod|mur|sil|vert|ind set; falls to /s$/
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'cervices'>, 'cervice'>;
+    // not in the matr|append or cod|… sets; falls to /s$/
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'radices'>, 'radice'>;
+    // rule 9 needs `tto` then optional `es`, not `tto`+`s`; falls to /s$/
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'lottos'>, 'lotto'>;
+    // matched by the `ss` alternative of rule 9, NOT /(ss)$/
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'boss'>, 'boss'>;
+    // rule 7 \b-anchored; `m` is not at a word boundary
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'dormice'>, never>;
+}
+
+namespace unmatched {
+    // Words that match no rule fall through to `never`.
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'cat'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'dog'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'geese'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'oxen'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'rice'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'tree'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'sky'>, never>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'genera'>, never>;
+    // @ts-expect-no-error
+    isAssignable<never, SingularizationRules<'cat'>>;
+}
+
+namespace caseFolding {
+    // Input is folded through Lowercase<T> before matching; output is lowercase.
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'MEN'>, 'man'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'Knives'>, 'knife'>;
+    // @ts-expect-no-error
+    isAssignable<SingularizationRules<'MATRICES'>, 'matrix'>;
+}

--- a/libraries/typed-pluralizer/src/pluralizer/singularization-rules.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/singularization-rules.ts
@@ -1,0 +1,152 @@
+// blakeembrey/pluralize v8.0.0 — https://github.com/plurals/pluralize
+// Singularization rules, transcribed from pluralize.js (the `singularRules`
+// array). Upstream `sanitizeWord` iterates the array back-to-front
+// (`while (len--)`) and uses the first rule that matches, so the LAST array
+// entry has the HIGHEST priority. The conditional chain below is therefore
+// written in reversed-array order: rule 22 (`/men$/`) is tested first, rule 0
+// (`/s$/`) last.
+//
+// This module is the rules layer ONLY — the uncountable and irregular gates
+// that upstream applies before `sanitizeWord` live in other modules.
+
+import { AnyOf, NoneOf, ReplaceEnding, Vowel } from '../util';
+
+// const rules = [
+//     [/s$/i, ''],
+//     [/(ss)$/i, '$1'],
+//     [/(wi|kni|(?:after|half|high|low|mid|non|night|[^\w]|^)li)ves$/i, '$1fe'],
+//     [/(ar|(?:wo|[ae])l|[eo][ao])ves$/i, '$1f'],
+//     [/ies$/i, 'y'],
+//     [/\b([pl]|zomb|(?:neck|cross)?t|coll|faer|food|gen|goon|group|lass|talk|goal|cut)ies$/i, '$1ie'],
+//     [/\b(mon|smil)ies$/i, '$1ey'],
+//     [/\b((?:tit)?m|l)ice$/i, '$1ouse'],
+//     [/(seraph|cherub)im$/i, '$1'],
+//     [/(x|ch|ss|sh|zz|tto|go|cho|alias|[^aou]us|t[lm]as|gas|(?:her|at|gr)o|[aeiou]ris)(?:es)?$/i, '$1'],
+//     [/(analy|diagno|parenthe|progno|synop|the|empha|cri|ne)(?:sis|ses)$/i, '$1sis'],
+//     [/(movie|twelve|abuse|e[mn]u)s$/i, '$1'],
+//     [/(test)(?:is|es)$/i, '$1is'],
+//     [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1us'],
+//     [/(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|quor)a$/i, '$1um'],
+//     [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)a$/i, '$1on'],
+//     [/(alumn|alg|vertebr)ae$/i, '$1a'],
+//     [/(cod|mur|sil|vert|ind)ices$/i, '$1ex'],
+//     [/(matr|append)ices$/i, '$1ix'],
+//     [/(pe)(rson|ople)$/i, '$1rson'],
+//     [/(child)ren$/i, '$1'],
+//     [/(eau)x?$/i, '$1'],
+//     [/men$/i, 'man'],
+// ];
+
+// Matching is case-insensitive (input is folded to lowercase first); output is
+// always lowercase. Unmatched input falls through to `never`.
+export type SingularizationRules<T extends string> = _SingularizationRules<Lowercase<T>>;
+
+type _SingularizationRules<T> =
+    // [/men$/i, 'man'],
+    T extends `${infer X}men` ? `${X}man`
+    : // [/(eau)x?$/i, '$1'],
+    T extends `${string}eau${'x' | ''}` ? ReplaceEnding<T, 'eaux' | 'eau', 'eau'>
+    : // [/(child)ren$/i, '$1'],
+    T extends `${string}children` ? ReplaceEnding<T, 'children', 'child'>
+    : // [/(pe)(rson|ople)$/i, '$1rson'],
+    T extends `${string}pe${'rson' | 'ople'}` ? ReplaceEnding<T, 'person' | 'people', 'person'>
+    : // [/(matr|append)ices$/i, '$1ix'],
+    T extends `${string}${'matr' | 'append'}ices` ? ReplaceEnding<T, 'ices', 'ix'>
+    : // [/(cod|mur|sil|vert|ind)ices$/i, '$1ex'],
+    T extends `${string}${'cod' | 'mur' | 'sil' | 'vert' | 'ind'}ices` ? ReplaceEnding<T, 'ices', 'ex'>
+    : // [/(alumn|alg|vertebr)ae$/i, '$1a'],
+    T extends `${string}${'alumn' | 'alg' | 'vertebr'}ae` ? ReplaceEnding<T, 'ae', 'a'>
+    : // [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)a$/i, '$1on'],
+    T extends (
+        `${string}${'apheli' | 'hyperbat' | 'periheli' | 'asyndet' | 'noumen' | 'phenomen' | 'criteri' | 'organ' | 'prolegomen' | 'hedr' | 'automat'}a`
+    ) ?
+        ReplaceEnding<T, 'a', 'on'>
+    : // [/(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|quor)a$/i, '$1um'],
+    T extends (
+        `${string}${'agend' | 'addend' | 'millenni' | 'dat' | 'extrem' | 'bacteri' | 'desiderat' | 'strat' | 'candelabr' | 'errat' | 'ov' | 'symposi' | 'curricul' | 'quor'}a`
+    ) ?
+        ReplaceEnding<T, 'a', 'um'>
+    : // [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1us'],
+    T extends (
+        `${string}${'alumn' | 'syllab' | 'vir' | 'radi' | 'nucle' | 'fung' | 'cact' | 'stimul' | 'termin' | 'bacill' | 'foc' | 'uter' | 'loc' | 'strat'}${'us' | 'i'}`
+    ) ?
+        ReplaceEnding<T, 'us' | 'i', 'us'>
+    : // [/(test)(?:is|es)$/i, '$1is'],
+    T extends `${string}test${'is' | 'es'}` ? ReplaceEnding<T, 'is' | 'es', 'is'>
+    : // [/(movie|twelve|abuse|e[mn]u)s$/i, '$1'],
+    T extends `${string}${'movie' | 'twelve' | 'abuse' | `e${AnyOf<'mn'>}u`}s` ? ReplaceEnding<T, 's', ''>
+    : // [/(analy|diagno|parenthe|progno|synop|the|empha|cri|ne)(?:sis|ses)$/i, '$1sis'],
+    T extends (
+        `${string}${'analy' | 'diagno' | 'parenthe' | 'progno' | 'synop' | 'the' | 'empha' | 'cri' | 'ne'}${'sis' | 'ses'}`
+    ) ?
+        ReplaceEnding<T, 'sis' | 'ses', 'sis'>
+    : // [/(x|ch|ss|sh|zz|tto|go|cho|alias|[^aou]us|t[lm]as|gas|(?:her|at|gr)o|[aeiou]ris)(?:es)?$/i, '$1'],
+    T extends (
+        `${string}${
+            | 'x'
+            | 'ch'
+            | 'ss'
+            | 'sh'
+            | 'zz'
+            | 'tto'
+            | 'go'
+            | 'cho'
+            | 'alias'
+            | `${NoneOf<'aou'>}us`
+            | `t${AnyOf<'lm'>}as`
+            | 'gas'
+            | `${'her' | 'at' | 'gr'}o`
+            | `${Vowel}ris`}${'es' | ''}`
+    ) ?
+        ReplaceEnding<T, 'es', ''>
+    : // [/(seraph|cherub)im$/i, '$1'],
+    T extends `${string}${'seraph' | 'cherub'}im` ? ReplaceEnding<T, 'im', ''>
+    : // [/\b((?:tit)?m|l)ice$/i, '$1ouse'],
+    // `\b` anchors the captured group at a word boundary; for letter-only words
+    // that means the start of the string, so this only fires for the exact words
+    // `mice`, `titmice`, `lice`.
+    T extends 'mice' | 'titmice' | 'lice' ? ReplaceEnding<T, 'ice', 'ouse'>
+    : // [/\b(mon|smil)ies$/i, '$1ey'],
+    // `\b`-anchored: only the exact words `monies`, `smilies`.
+    T extends 'monies' | 'smilies' ? ReplaceEnding<T, 'ies', 'ey'>
+    : // [/\b([pl]|zomb|(?:neck|cross)?t|coll|faer|food|gen|goon|group|lass|talk|goal|cut)ies$/i, '$1ie'],
+    // `\b`-anchored: the captured stem sits at the start of the word, so no
+    // leading `${string}`.
+    T extends (
+        `${
+            | 'p'
+            | 'l'
+            | 'zomb'
+            | `${'neck' | 'cross' | ''}t`
+            | 'coll'
+            | 'faer'
+            | 'food'
+            | 'gen'
+            | 'goon'
+            | 'group'
+            | 'lass'
+            | 'talk'
+            | 'goal'
+            | 'cut'}ies`
+    ) ?
+        ReplaceEnding<T, 'ies', 'ie'>
+    : // [/ies$/i, 'y'],
+    T extends `${string}ies` ? ReplaceEnding<T, 'ies', 'y'>
+    : // [/(ar|(?:wo|[ae])l|[eo][ao])ves$/i, '$1f'],
+    T extends `${string}${'ar' | `${'wo' | AnyOf<'ae'>}l` | `${AnyOf<'eo'>}${AnyOf<'ao'>}`}ves` ?
+        ReplaceEnding<T, 'ves', 'f'>
+    : // [/(wi|kni|(?:after|half|high|low|mid|non|night|[^\w]|^)li)ves$/i, '$1fe'],
+    // `wi`/`kni` are unanchored; the `li` branch requires a preceding word
+    // boundary — `^` (whole word `lives`) or one of the listed prefixes. The
+    // `[^\w]li` alternative cannot fire for letter-only input and is omitted.
+    T extends (
+        `${string}${'wi' | 'kni'}ves` | `${'after' | 'half' | 'high' | 'low' | 'mid' | 'non' | 'night' | ''}lives`
+    ) ?
+        ReplaceEnding<T, 'ves', 'fe'>
+    : // [/(ss)$/i, '$1'],
+    // Identity for `ss` endings. Shadowed in practice by the `ss` alternative of
+    // the `(x|ch|ss|…)` rule above (higher priority), which also returns `$1`.
+    T extends `${string}ss` ? T
+    : // [/s$/i, ''],
+    T extends `${infer X}s` ? X
+    : never;


### PR DESCRIPTION
## What

Adds `libraries/typed-pluralizer/src/pluralizer/singularization-rules.ts` — the `singularizationRules` array of blakeembrey/pluralize v8.0.0 transcribed into a template-literal conditional type, mirroring `pluralization-rules.ts` exactly:

- `export type SingularizationRules<T extends string> = _SingularizationRules<Lowercase<T>>` folding into a `_`-prefixed internal.
- Bottom-up semantics preserved: upstream `sanitizeWord` iterates the array back-to-front (`while (len--)`), so the **last** array entry has the **highest** priority. The conditional chain is written in reversed-array order (rule 22 `/men$/` first, rule 0 `/s$/` last).
- The source regex/replacement comment sits adjacent to every arm; file-top cites blakeembrey/pluralize v8.0.0.
- Rules layer **only** — the uncountable/irregular gates upstream applies before `sanitizeWord` live in other modules.

Also adds `singularization-rules.d.test.ts`, generated from the verified dataset and grouped by rule arm (mirrors the existing `.d.test.ts` conventions).

No `index.ts` barrel change — export wiring is a later PR. No new util helper needed; reused `AnyOf`/`NoneOf`/`Vowel`/`ReplaceEnding`.

## Divergences

**Accepted (the only intended one):** matching is case-insensitive via the `Lowercase<T>` fold and output is always lowercase; upstream `/i` regexes preserve case.

**TS-limitation divergences** (documented at the arm site):
- The `\b`/`^`/`[^\w]` anchors on the `-ice` (`mice`/`titmice`/`lice`), `-ies` (rules 5 & 6) and `li`-branch of the `-ves` rule have no exact template-literal analogue. They are modelled as start-of-word matches: the anchored stem sits at the start of the word (exact-word unions, no leading `${string}`). This is faithful for letter-only input — verified against the oracle (e.g. `azombies`, `dormice`, `gaslives`, `ilives` correctly fall through past the anchored rule).
- The `[^\w]li` alternative of the `li`-ves rule cannot fire for letter-only words and is omitted.

## How verified

A node oracle replicates `sanitizeWord` over the `singularRules` array exactly — back-to-front iteration, first-match short-circuit, `$1` interpolation. Each word's actual type output was resolved with the tsc sentinel-assignment probe (`runprobe`-style) pointed at this package's source and `node_modules/.bin/tsc`.

- **300+ distinct words** probed: >=2 positives per rule arm, cross-arm collision/priority probes, boundary negatives, fall-through words, and the classic round-trip families (knives/wives, matrices/indices, oxen, analyses/crises, men/women, mice/lice).
- **Oracle and resolved types agree on every case**, zero divergences (modulo the accepted lowercase fold). Non-letter inputs and unmatched words fall through to `never`, matching the oracle.

The `.d.test.ts` encodes the verified dataset as `isAssignable` assertions, all `@ts-expect-no-error` (no known-wrongs — every arm is faithful). `rush build --to typed-pluralizer` passes clean.