### PR TITLE
feat(typed-pluralizer): complete pluralization rules with true bottom-up priority

### DIFF
--- a/libraries/typed-pluralizer/src/pluralizer/pluralization-rules.d.test.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/pluralization-rules.d.test.ts
@@ -3,31 +3,398 @@ import { PluralizationRules } from './pluralization-rules';
 declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
 declare function isAssignable<TExpected>(actual?: TExpected): void;
 
-// Coverage for the implemented regex-derived rules. Assertions pin what the
-// rules emit TODAY; cases that are linguistically wrong but expected-someday are
-// marked @ts-expect-error with the actual produced literal in the TODO.
+// Verification gate for the full pluralizationRules layer (blakeembrey/pluralize
+// v8.0.0) reordered to TRUE bottom-up priority. Every assertion is the resolved
+// type output confirmed against a node oracle that transcribes sanitizeWord +
+// the full rule array. Namespaces are grouped by the upstream array entry the
+// word resolves to, ordered highest priority (last array entry) first.
 
-namespace axis {
+namespace thou {
     // @ts-expect-no-error
-    isAssignable<PluralizationRules<'axis'>, 'axes'>;
+    isAssignable<PluralizationRules<'thou'>, 'you'>;
 }
 
-namespace alias {
+namespace manMen {
     // @ts-expect-no-error
-    isAssignable<PluralizationRules<'alias'>, 'aliases'>;
+    isAssignable<PluralizationRules<'man'>, 'men'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'woman'>, 'women'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'men'>, 'men'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'women'>, 'women'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'human'>, 'humen'>;
 }
 
-namespace alumnus {
-    // expected 'alumni'
-    // @ts-expect-error
-    isAssignable<PluralizationRules<'alumnus'>, 'alumni'>; // TODO known-wrong: produces 'alumnuses'
+namespace eauxIdentity {
     // @ts-expect-no-error
-    isAssignable<PluralizationRules<'alumnus'>, 'alumnuses'>;
+    isAssignable<PluralizationRules<'bureaux'>, 'bureaux'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'tableaux'>, 'tableaux'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'plateaux'>, 'plateaux'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'chateaux'>, 'chateaux'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'eaux'>, 'eaux'>;
 }
 
-namespace hero {
+namespace children {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'child'>, 'children'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'children'>, 'children'>;
+}
+
+namespace people {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'person'>, 'people'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'people'>, 'people'>;
+}
+
+namespace miceLice {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'mouse'>, 'mice'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'mice'>, 'mice'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'louse'>, 'lice'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'titmouse'>, 'titmice'>;
+}
+
+namespace icesMatrIndEx {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'matrix'>, 'matrices'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'index'>, 'indices'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'appendix'>, 'appendices'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'vertex'>, 'vertices'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'codex'>, 'codices'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'silex'>, 'silices'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'murex'>, 'murices'>;
+}
+
+namespace esXChSsShZz {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'helix'>, 'helixes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'box'>, 'boxes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'church'>, 'churches'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'dish'>, 'dishes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'buzz'>, 'buzzes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'fizz'>, 'fizzes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'fox'>, 'foxes'>;
+}
+
+namespace consonantYToIes {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'baby'>, 'babies'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'fly'>, 'flies'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'sky'>, 'skies'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cry'>, 'cries'>;
+}
+
+namespace fToVes {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'knife'>, 'knives'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'wife'>, 'wives'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'life'>, 'lives'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'elf'>, 'elves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'loaf'>, 'loaves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'leaf'>, 'leaves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'hoof'>, 'hooves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'wolf'>, 'wolves'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'half'>, 'halves'>;
+}
+
+namespace sisToSes {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'crisis'>, 'crises'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'sis'>, 'ses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'analysis'>, 'analyses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'basis'>, 'bases'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'thesis'>, 'theses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'chassis'>, 'chasses'>;
+}
+
+namespace aOnToA {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'criterion'>, 'criteria'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'phenomenon'>, 'phenomena'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'organon'>, 'organa'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'automaton'>, 'automata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'prolegomenon'>, 'prolegomena'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'automata'>, 'automata'>;
+}
+
+namespace aUmToA {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'datum'>, 'data'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'agendum'>, 'agenda'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'ovum'>, 'ova'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'stratum'>, 'strata'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'millennium'>, 'millennia'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'symposium'>, 'symposia'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'curriculum'>, 'curricula'>;
+}
+
+namespace oToOes {
     // @ts-expect-no-error
     isAssignable<PluralizationRules<'hero'>, 'heroes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'potato'>, 'potatoes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'tomato'>, 'tomatoes'>;
+}
+
+namespace seraphimCherubim {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'seraph'>, 'seraphim'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cherub'>, 'cherubim'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'seraphim'>, 'seraphim'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cherubim'>, 'cherubim'>;
+}
+
+namespace aAeToAe {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'alumna'>, 'alumnae'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'alga'>, 'algae'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'vertebra'>, 'vertebrae'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'alumnae'>, 'alumnae'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'algae'>, 'algae'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'vertebrae'>, 'vertebrae'>;
+}
+
+namespace usIToI {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'alumnus'>, 'alumni'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cactus'>, 'cacti'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'focus'>, 'foci'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'virus'>, 'viri'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'radius'>, 'radii'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'locus'>, 'loci'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'fungus'>, 'fungi'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'stimulus'>, 'stimuli'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'nucleus'>, 'nuclei'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'syllabus'>, 'syllabi'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'bacillus'>, 'bacilli'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'uterus'>, 'uteri'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'terminus'>, 'termini'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'alumni'>, 'alumni'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cacti'>, 'cacti'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'foci'>, 'foci'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'radii'>, 'radii'>;
+}
+
+namespace iasLasAsAmIdentity {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'bias'>, 'bias'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'areas'>, 'areas'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'pizzas'>, 'pizzas'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'liam'>, 'liam'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'guam'>, 'guam'>;
+}
+
+namespace emuMenu {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'emu'>, 'emus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'menu'>, 'menus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'emus'>, 'emus'>;
+}
+
+namespace usAsEs {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'bus'>, 'buses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'alias'>, 'aliases'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'campus'>, 'campuses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'atlas'>, 'atlases'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'gas'>, 'gases'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'ris'>, 'rises'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'genius'>, 'geniuses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'census'>, 'censuses'>;
+}
+
+namespace axTestIsToEs {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'axis'>, 'axes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'testis'>, 'testes'>;
+}
+
+namespace eseIdentity {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'chinese'>, 'chinese'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'japanese'>, 'japanese'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'manese'>, 'manese'>;
+}
+
+namespace sFallback {
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cat'>, 'cats'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'dog'>, 'dogs'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'goose'>, 'gooses'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'monkey'>, 'monkeys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'donkey'>, 'donkeys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'alley'>, 'alleys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'valley'>, 'valleys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'chimney'>, 'chimneys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'trolley'>, 'trolleys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'guy'>, 'guys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'day'>, 'days'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'key'>, 'keys'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'roof'>, 'roofs'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'proof'>, 'proofs'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'torpedo'>, 'torpedos'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'photo'>, 'photos'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'canvas'>, 'canvas'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'axes'>, 'axes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'testes'>, 'testes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'beau'>, 'beaus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'tableau'>, 'tableaus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'eau'>, 'eaus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'chateau'>, 'chateaus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'bureau'>, 'bureaus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'plateau'>, 'plateaus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'grotto'>, 'grottos'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'milieu'>, 'milieus'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'quiz'>, 'quizs'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cafe'>, 'cafes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'naive'>, 'naives'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'resume'>, 'resumes'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'foo'>, 'foos'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'bird'>, 'birds'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'table'>, 'tables'>;
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'window'>, 'windows'>;
+}
+
+namespace nonAsciiDivergence {
+    // Approximation of [/[^\u0000-\u007F]$/i, '$0']: 'last char is not an
+    // ASCII lowercase letter' stands in for 'code point > 127'. Genuine
+    // non-ASCII letter endings agree with upstream identity.
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'café'>, 'café'>;
+    // 'naïve' ends in an ASCII letter, so the rule does not fire and /s?$/ applies.
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'naïve'>, 'naïves'>;
+    // Divergence class: an ASCII non-letter ending (e.g. a digit) takes this
+    // identity arm here, whereas upstream falls through to /s?$/ and appends 's'.
+    // The verified output is 'cat5' (identity). Upstream emits 'cat5s'
+    // (its [^\u0000-\u007F] rule does not match the ASCII '5', so /s?$/ runs).
+    // @ts-expect-no-error
+    isAssignable<PluralizationRules<'cat5'>, 'cat5'>;
 }
 
 namespace caseFolding {
@@ -36,12 +403,8 @@ namespace caseFolding {
     isAssignable<PluralizationRules<'AXIS'>, 'axes'>;
     // @ts-expect-no-error
     isAssignable<PluralizationRules<'Hero'>, 'heroes'>;
-}
-
-namespace unmatched {
-    // Words that match no implemented rule fall through to `never`.
     // @ts-expect-no-error
-    isAssignable<PluralizationRules<'cat'>, never>;
+    isAssignable<PluralizationRules<'CHILD'>, 'children'>;
     // @ts-expect-no-error
-    isAssignable<never, PluralizationRules<'cat'>>;
+    isAssignable<PluralizationRules<'Thou'>, 'you'>;
 }

--- a/libraries/typed-pluralizer/src/pluralizer/pluralization-rules.ts
+++ b/libraries/typed-pluralizer/src/pluralizer/pluralization-rules.ts
@@ -1,77 +1,104 @@
-import { AnyOf, Consonant, Letter, NoneOf, Not, ReplaceEnding, Vowel } from '../util';
+// blakeembrey/pluralize v8.0.0 — https://github.com/plurals/pluralize
+//
+// This module implements the `pluralizationRules` LAYER of pluralize: what
+// `sanitizeWord` does with the rule array. The uncountable and irregular gates
+// that the public `pluralize()` applies BEFORE the rules run live in other
+// modules — this type deliberately exercises the rules in isolation.
+//
+// TRUE PRIORITY SEMANTICS. `sanitizeWord` iterates the array BOTTOM-UP
+// (`while (len--)`) and returns on the first regex that matches, so the LAST
+// array entry has the HIGHEST priority. The ternary chain below is therefore
+// ordered from the last array entry (`['thou','you']`) down to the first
+// (`/s?$/ -> 's'`), which is the lowest-priority fallback. Each arm carries the
+// upstream `[regex, replacement]` it implements, in array order, immediately
+// adjacent.
+//
+// Accepted divergence: matching is case-insensitive via the `Lowercase<T>` fold
+// and output is always lowercase; upstream's `/i` regexes preserve input case.
 
-// const rules = [
-//     [/s?$/i, 's'],
-//     [/[^\u0000-\u007F]$/i, '$0'],
-//     [/([^aeiou]ese)$/i, '$1'],
-//     [/(ax|test)is$/i, '$1es'],
-//     [/(alias|[^aou]us|t[lm]as|gas|ris)$/i, '$1es'],
-//     [/(e[mn]u)s?$/i, '$1s'],
-//     [/([^l]ias|[aeiou]las|[ejzr]as|[iu]am)$/i, '$1'],
-//     [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1i'],
-//     [/(alumn|alg|vertebr)(?:a|ae)$/i, '$1ae'],
-//     [/(seraph|cherub)(?:im)?$/i, '$1im'],
-//     [/(her|at|gr)o$/i, '$1oes'],
-//     [/(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|automat|quor)(?:a|um)$/i, '$1a'],
-//     [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)(?:a|on)$/i, '$1a'],
-//     [/sis$/i, 'ses'],
-//     [/(?:(kni|wi|li)fe|(ar|l|ea|eo|oa|hoo)f)$/i, '$1$2ves'],
-//     [/([^aeiouy]|qu)y$/i, '$1ies'],
-//     [/([^ch][ieo][ln])ey$/i, '$1ies'],
-//     [/(x|ch|ss|sh|zz)$/i, '$1es'],
-//     [/(matr|cod|mur|sil|vert|ind|append)(?:ix|ex)$/i, '$1ices'],
-//     [/\b((?:tit)?m|l)(?:ice|ouse)$/i, '$1ice'],
-//     [/(pe)(?:rson|ople)$/i, '$1ople'],
-//     [/(child)(?:ren)?$/i, '$1ren'],
-//     [/eaux$/i, '$0'],
-//     [/m[ae]n$/i, 'men'],
-//     ['thou', 'you']
-// ];
+import { AnyOf, Consonant, LastChar, Letter, NoneOf, ReplaceEnding, Vowel } from '../util';
 
-// Matching is case-insensitive (input is folded to lowercase first); output is
-// always lowercase. Unmatched input falls through to `never` until the rule
-// set is complete.
+// `[^aeiouy]` in the lowercase-letter domain: a consonant other than `y`.
+type ConsonantNotY = Exclude<Consonant, 'y'>;
+
 export type PluralizationRules<T extends string> = _PluralizationRules<Lowercase<T>>;
 
-type _PluralizationRules<T> =
-    // //[/[^\u0000-\u007F]$/i, '$0'],
-    // T extends `${infer X}${Not<infer Y, Letter>}` ? X :
-
-    // [/([^aeiou]ese)$/i, '$1'],
-    T extends `${string}${Consonant}ese` ? T
-    : // [/(ax|test)is$/i, '$1es'],
-    T extends `${infer X}${'ax' | 'test'}is` ? ReplaceEnding<T, 'is', 'es'>
-    : // [/(alias|[^aou]us|t[lm]as|gas|ris)$/i, '$1es'],
-    T extends `${infer X}${'alias' | `${NoneOf<'aou'>}us` | `t${AnyOf<'lm'>}as` | 'gas' | 'ris'}` ? `${T}es`
-    : // [/(e[mn]u)s?$/i, '$1s'],
-    T extends `${string}e${AnyOf<'mn'>}${'us' | 'u'}` ? ReplaceEnding<T, 'us' | 'u', 'us'>
-    : // ([^l]ias|[aeiou]las|[ejzr]as|[iu]am)$, '$1'],
-    T extends `${infer X}${`${NoneOf<'l'>}ias` | `${Vowel}las` | `${AnyOf<'ejzr'>}as` | `${AnyOf<'iu'>}am`}` ? T
-    : // [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1i'],
+type _PluralizationRules<T extends string> =
+    // ['thou', 'you']  (sanitizeRule wraps as /^thou$/i)
+    T extends 'thou' ? 'you'
+    : // [/m[ae]n$/i, 'men']
+    T extends `${string}${'man' | 'men'}` ? ReplaceEnding<T, 'man' | 'men', 'men'>
+    : // [/eaux$/i, '$0']  (identity)
+    T extends `${string}eaux` ? T
+    : // [/(child)(?:ren)?$/i, '$1ren']
+    T extends `${infer X}child${'ren' | ''}` ? `${X}children`
+    : // [/(pe)(?:rson|ople)$/i, '$1ople']
+    T extends `${infer X}pe${'rson' | 'ople'}` ? `${X}people`
+    : // [/\b((?:tit)?m|l)(?:ice|ouse)$/i, '$1ice']
+    // The leading \b plus the lowercase-letter input domain means the
+    // (tit)?m | l group can only sit at the word start (any letter prefix
+    // would defeat the boundary), so the rule reduces to these whole words.
+    T extends 'mouse' | 'mice' ? 'mice'
+    : T extends 'louse' | 'lice' ? 'lice'
+    : T extends 'titmouse' | 'titmice' ? 'titmice'
+    : // [/(matr|cod|mur|sil|vert|ind|append)(?:ix|ex)$/i, '$1ices']
+    T extends `${string}${'matr' | 'cod' | 'mur' | 'sil' | 'vert' | 'ind' | 'append'}${'ix' | 'ex'}` ?
+        ReplaceEnding<T, 'ix' | 'ex', 'ices'>
+    : // [/(x|ch|ss|sh|zz)$/i, '$1es']
+    T extends `${string}${'x' | 'ch' | 'ss' | 'sh' | 'zz'}` ? `${T}es`
+    : // [/([^ch][ieo][ln])ey$/i, '$1ies']
+    T extends `${string}${NoneOf<'ch'>}${AnyOf<'ieo'>}${AnyOf<'ln'>}ey` ? ReplaceEnding<T, 'ey', 'ies'>
+    : // [/([^aeiouy]|qu)y$/i, '$1ies']
+    T extends `${string}${ConsonantNotY | 'qu'}y` ? ReplaceEnding<T, 'y', 'ies'>
+    : // [/(?:(kni|wi|li)fe|(ar|l|ea|eo|oa|hoo)f)$/i, '$1$2ves']
+    T extends `${string}${'kni' | 'wi' | 'li'}fe` ? ReplaceEnding<T, 'fe', 'ves'>
+    : T extends `${string}${'ar' | 'l' | 'ea' | 'eo' | 'oa' | 'hoo'}f` ? ReplaceEnding<T, 'f', 'ves'>
+    : // [/sis$/i, 'ses']
+    T extends `${string}sis` ? ReplaceEnding<T, 'sis', 'ses'>
+    : // [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)(?:a|on)$/i, '$1a']
+    T extends (
+        `${string}${'apheli' | 'hyperbat' | 'periheli' | 'asyndet' | 'noumen' | 'phenomen' | 'criteri' | 'organ' | 'prolegomen' | 'hedr' | 'automat'}${'a' | 'on'}`
+    ) ?
+        ReplaceEnding<T, 'a' | 'on', 'a'>
+    : // [/(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|automat|quor)(?:a|um)$/i, '$1a']
+    T extends (
+        `${string}${'agend' | 'addend' | 'millenni' | 'dat' | 'extrem' | 'bacteri' | 'desiderat' | 'strat' | 'candelabr' | 'errat' | 'ov' | 'symposi' | 'curricul' | 'automat' | 'quor'}${'a' | 'um'}`
+    ) ?
+        ReplaceEnding<T, 'a' | 'um', 'a'>
+    : // [/(her|at|gr)o$/i, '$1oes']
+    T extends `${string}${'her' | 'at' | 'gr'}o` ? ReplaceEnding<T, 'o', 'oes'>
+    : // [/(seraph|cherub)(?:im)?$/i, '$1im']
+    T extends `${string}${'seraph' | 'cherub'}${'im' | ''}` ? `${ReplaceEnding<T, 'im', ''>}im`
+    : // [/(alumn|alg|vertebr)(?:a|ae)$/i, '$1ae']
+    T extends `${string}${'alumn' | 'alg' | 'vertebr'}${'a' | 'ae'}` ? `${ReplaceEnding<T, 'a' | 'ae', ''>}ae`
+    : // [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1i']
     T extends (
         `${string}${'alumn' | 'syllab' | 'vir' | 'radi' | 'nucle' | 'fung' | 'cact' | 'stimul' | 'termin' | 'bacill' | 'foc' | 'uter' | 'loc' | 'strat'}${'us' | 'i'}`
     ) ?
-        ReplaceEnding<T, 'us' | 'i', `i`>
-    : // [/(alumn|alg|vertebr)(?:a|ae)$/i, '$1ae'],
-    T extends `${string}${'alumn' | 'alg' | 'vertebr'}${'a' | 'ae' | ''}` ? `${ReplaceEnding<T, 'a' | 'ae', ''>}ae`
-    : // [/(seraph|cherub)(?:im)?$/i, '$1im'],
-    // T extends `${string}${'seraph' | 'cherub' | 'vertebr'}` ? `${T}ae` :
-    T extends `${string}${'seraph' | 'cherub' | 'vertebr'}${'im' | ''}` ? `${ReplaceEnding<T, 'im', ''>}im`
-    : // [/(her|at|gr)o$/i, '$1oes'],
-    T extends `${string}${'her' | 'at' | 'gr'}o` ? ReplaceEnding<T, 'o', 'oes'>
-    : // [/(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|automat|quor)(?:a|um)$/i, '$1a'],
-        // [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)(?:a|on)$/i, '$1a'],
-        // [/sis$/i, 'ses'],
-        // [/(?:(kni|wi|li)fe|(ar|l|ea|eo|oa|hoo)f)$/i, '$1$2ves'],
-        // [/([^aeiouy]|qu)y$/i, '$1ies'],
-        // [/([^ch][ieo][ln])ey$/i, '$1ies'],
-        // [/(x|ch|ss|sh|zz)$/i, '$1es'],
-        // [/(matr|cod|mur|sil|vert|ind|append)(?:ix|ex)$/i, '$1ices'],
-        // [/\b((?:tit)?m|l)(?:ice|ouse)$/i, '$1ice'],
-        // [/(pe)(?:rson|ople)$/i, '$1ople'],
-        // [/(child)(?:ren)?$/i, '$1ren'],
-        // [/eaux$/i, '$0'],
-        // [/m[ae]n$/i, 'men'],
-        // ['thou', 'you']
+        ReplaceEnding<T, 'us' | 'i', 'i'>
+    : // [/([^l]ias|[aeiou]las|[ejzr]as|[iu]am)$/i, '$1']  (identity)
+    T extends `${string}${`${NoneOf<'l'>}ias` | `${Vowel}las` | `${AnyOf<'ejzr'>}as` | `${AnyOf<'iu'>}am`}` ? T
+    : // [/(e[mn]u)s?$/i, '$1s']
+    T extends `${string}e${AnyOf<'mn'>}${'us' | 'u'}` ? ReplaceEnding<T, 'us' | 'u', 'us'>
+    : // [/(alias|[^aou]us|t[lm]as|gas|ris)$/i, '$1es']
+    T extends `${string}${'alias' | `${NoneOf<'aou'>}us` | `t${AnyOf<'lm'>}as` | 'gas' | 'ris'}` ? `${T}es`
+    : // [/(ax|test)is$/i, '$1es']
+    T extends `${string}${'ax' | 'test'}is` ? ReplaceEnding<T, 'is', 'es'>
+    : // [/([^aeiou]ese)$/i, '$1']  (identity)
+    T extends `${string}${Consonant}ese` ? T
+    : // [/[^\u0000-\u007F]$/i, '$0']  (identity, second-lowest priority)
+    // TS literal types cannot test a UTF-16 code point against 127. The
+    // input is folded through Lowercase<T> and the Letter class is
+    // ASCII-lowercase-only, so we approximate the rule as "last char is not
+    // an ASCII lowercase letter". Documented divergence class: a word whose
+    // final char is an ASCII non-letter (digit/punctuation, e.g. 'cat5')
+    // takes this identity arm here, whereas upstream — where that char IS in
+    // 0x00-0x7F — would fall through to /s?$/ and append 's'. Genuine
+    // non-ASCII-letter endings ('café') agree with upstream: identity.
+    LastChar<T> extends Letter ? _SFallback<T>
+    : T;
 
-        never;
+// [/s?$/i, 's']  (lowest-priority fallback). On an s-ending word /s?$/ matches
+// the trailing s and rewrites it to 's' (identity, e.g. 'canvas' -> 'canvas');
+// otherwise it matches the empty end position and appends 's' (cat -> cats).
+type _SFallback<T extends string> = T extends `${string}s` ? T : `${T}s`;

--- a/libraries/typed-pluralizer/src/util/index.ts
+++ b/libraries/typed-pluralizer/src/util/index.ts
@@ -45,3 +45,13 @@ export type AnyOf<T> =
 export type NoneOf<T> = Exclude<Letter, AnyOf<T>>;
 
 export type Not<T extends string, U> = T extends U ? never : T;
+
+// The final single character of a string literal. Recurses to peel the head
+// until one char remains. `${infer X}${Not<infer Y, Letter>}` cannot do this —
+// `Y` binds the whole tail after the first char, not a single trailing char.
+export type LastChar<T extends string> =
+    T extends `${infer Head}${infer Rest}` ?
+        Rest extends '' ?
+            T
+        :   LastChar<Rest>
+    :   never;


### PR DESCRIPTION
Completes `_PluralizationRules` so it implements the full `pluralizationRules`
array of blakeembrey/pluralize v8.0.0 with its true priority semantics, replacing
the previous top-down partial that fell through to `never`.

## What changed

- **Bottom-up priority.** `sanitizeWord` iterates the rule array with
  `while (len--)` and returns on the first regex that matches, so the *last*
  array entry has the *highest* priority. The ternary chain is now ordered from
  the last entry (`['thou','you']`) down to the lowest-priority fallback
  (`/s?$/ -> 's'`). Every arm carries its upstream `[regex, replacement]` in
  array order, immediately adjacent, and the prior hand-derived comment block was
  replaced with the regexes transcribed from the fetched source.
- **`/s?$/` fallback** replaces the `never` fallthrough: appends `s`, or is
  identity on an s-ending word (`canvas -> canvas`). The stale header comment that
  said unmatched input falls to `never` is gone.
- **Non-ASCII identity rule** (the `[^-]$` arm, second-lowest
  priority). TS literal types cannot test a UTF-16 code point against 127, so it
  is approximated as "last char is not an ASCII lowercase letter" via a new
  `LastChar` util helper. Genuine non-ASCII *letter* endings (`café`) — the actual
  intent of the upstream rule — agree with upstream identity. The single bounded
  divergence is an ASCII *non-letter* ending (digit/punctuation, e.g. `cat5`):
  this type takes identity (`cat5`), whereas upstream falls through to `/s?$/`
  and appends `s` (`cat5s`), because `5` is inside `0x00-0x7F`. Documented at the
  arm site and pinned in the test.
- **`['thou','you']`** is a genuine `pluralizationRules` entry, not an irregular
  pair. `sanitizeRule` wraps the trailing string as `/^thou$/i`, so it is the
  highest-priority exact-match rule; it stays in this file. (It is absent from the
  irregular array, which is handled by the irregular-nouns module.)
- **Word-boundary collapse.** The `\b((?:tit)?m|l)(?:ice|ouse)$` rule reduces to
  the whole words `mouse/mice/louse/lice/titmouse/titmice`: in the lowercase
  single-word input domain, any letter prefix defeats the `\b`, so e.g. `blouse`
  and `dormouse` correctly fall through to `/s?$/`.

## New util helper

`LastChar<T>` — the final single character of a string literal, by recursion.
Genuinely generic (peels the head until one char remains); the
`${infer X}${Not<infer Y, Letter>}` form cannot do this because `Y` binds the
whole tail after the first char.

## Accepted divergence (unchanged from the module's existing contract)

Matching is case-insensitive via the `Lowercase<T>` fold and output is always
lowercase; upstream's `/i` regexes preserve input case.

## Verification

A node oracle transcribes `sanitizeWord` + the full `pluralizationRules` array
verbatim (bottom-up `while (len--)`, first-match short-circuit, `replace` /
`interpolate` / `restoreCase`), exercising the rules layer in isolation (no
uncountable/irregular gates). It was cross-checked against the real upstream
`pluralize.plural` over 71 gate-free words (0 diffs), confirming the
transcription. The dataset (>=2 positives per rule, bottom-up collision probes
that pin the reorder, boundary negatives, and fall-through words) was resolved to
actual type outputs via the tsc sentinel-assignment probe and compared to the
oracle: **155 cases, 154 agree, 1 documented TS-limitation divergence (`cat5`).**

The regenerated `pluralization-rules.d.test.ts` encodes the verified dataset as
`isAssignable` / `@ts-expect-no-error` assertions grouped by rule (highest
priority first), mirroring the sibling `from-infinitive.d.test.ts` convention and
keeping the `caseFolding` namespace.

`rush build --to typed-pluralizer` passes clean (full rebuild, no cache).

No `index.ts` barrel was touched — export wiring is a later PR.
