### PR TITLE
feat(type-helpers): export UnionToTuple; deprecate Cast

### DIFF
--- a/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-union-to-tuple_2026-06-06-01-00.json
+++ b/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-union-to-tuple_2026-06-06-01-00.json
@@ -4,6 +4,11 @@
       "comment": "Export UnionToTuple<T>",
       "type": "minor",
       "packageName": "@rhombus-toolkit/type-helpers"
+    },
+    {
+      "comment": "Deprecate Cast<V, T>; use an intersection (e.g. `string & T`) instead",
+      "type": "patch",
+      "packageName": "@rhombus-toolkit/type-helpers"
     }
   ],
   "packageName": "@rhombus-toolkit/type-helpers",

--- a/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-union-to-tuple_2026-06-06-01-00.json
+++ b/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-union-to-tuple_2026-06-06-01-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Export UnionToTuple<T>",
+      "type": "minor",
+      "packageName": "@rhombus-toolkit/type-helpers"
+    }
+  ],
+  "packageName": "@rhombus-toolkit/type-helpers",
+  "email": "2511516+fnrhombus@users.noreply.github.com"
+}

--- a/libraries/type-helpers/src/cast.d.ts
+++ b/libraries/type-helpers/src/cast.d.ts
@@ -1,1 +1,4 @@
+/**
+ * @deprecated Use an intersection instead — e.g. `string & T` in place of `Cast<T, string>`.
+ */
 export type Cast<V, T> = V extends T ? V : T;

--- a/libraries/type-helpers/src/index.ts
+++ b/libraries/type-helpers/src/index.ts
@@ -12,9 +12,10 @@ export * from './opaque';
 export * as obj from './obj';
 export * from './range';
 export * from './restify';
-export type {Stringable, Str, Join, ClearEmpties, Split} from './string';
+export type { Stringable, Str, Join, ClearEmpties, Split } from './string';
 
 export * from './truthy';
 // export * from './tuple';
-export type {UnionToIntersection} from './union-to-intersection';
+export type { UnionToIntersection } from './union-to-intersection';
+export type { UnionToTuple } from './union-to-tuple';
 export * from './utility-types';

--- a/libraries/type-helpers/src/union-to-tuple.d.ts
+++ b/libraries/type-helpers/src/union-to-tuple.d.ts
@@ -1,0 +1,10 @@
+import { Func } from '@rhombus-toolkit/func';
+
+type Contravariant<T> = Func<[T]>;
+type ForceCV<T> = T extends unknown ? Contravariant<T> : never;
+type ExtractCV<T> = T extends Contravariant<infer I> ? I : never;
+
+type UnionToIntersection<T> = ForceCV<T> extends Contravariant<infer I> ? I : never;
+type LastInUnion<T> = ExtractCV<UnionToIntersection<ForceCV<T>>>; // extends Contravariant<infer R> ? R : never;
+export type UnionToTuple<T, Last = LastInUnion<T>> =
+    [T] extends [never] ? readonly [] : readonly [...UnionToTuple<Exclude<T, Last>>, Last];

--- a/libraries/type-helpers/src/union-to-tuple.test.ts
+++ b/libraries/type-helpers/src/union-to-tuple.test.ts
@@ -1,0 +1,42 @@
+import { UnionToTuple } from './index';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+namespace multiMemberTest {
+    type Subject = UnionToTuple<'a' | 'b' | 'c'>;
+    type Expected = readonly ['a', 'b', 'c'];
+
+    // @ts-expect-no-error
+    isAssignable<Subject, Expected>;
+    // @ts-expect-no-error
+    isAssignable<Expected, Subject>;
+
+    // wrong order
+    // @ts-expect-error
+    isAssignable<Subject, readonly ['c', 'b', 'a']>;
+    // wrong length
+    // @ts-expect-error
+    isAssignable<Subject, readonly ['a', 'b']>;
+}
+
+namespace neverTest {
+    type Subject = UnionToTuple<never>;
+
+    // @ts-expect-no-error
+    isAssignable<Subject, readonly []>;
+    // @ts-expect-no-error
+    isAssignable<readonly [], Subject>;
+}
+
+namespace singleMemberTest {
+    type Subject = UnionToTuple<'x'>;
+
+    // @ts-expect-no-error
+    isAssignable<Subject, readonly ['x']>;
+    // @ts-expect-no-error
+    isAssignable<readonly ['x'], Subject>;
+
+    // @ts-expect-error
+    isAssignable<Subject, readonly ['y']>;
+}


### PR DESCRIPTION
## Summary

- Add and export `UnionToTuple<T>` — decomposes a union into an ordered `readonly` tuple via contravariant inference. The file-local `UnionToIntersection` helper in `union-to-tuple.d.ts` is intentionally distinct from the exported one and is not re-exported, so there is no conflict.
- Deprecate `Cast<V, T>` with a JSDoc `@deprecated` pointing at a plain intersection (`string & T`). Internal usages in `array.d.ts` and `counter.alt.d.ts` are left as-is; the build does not flag the self-usage.
- Type-test assertions live in `union-to-tuple.test.ts` (not `.d.test.ts`, which would render them inert); `heft build` compiles and type-checks them as the gate.
- `Func` (readonly args) and `Join` were verified already-satisfied upstream of this change — no edits needed there.

## Test plan

- [x] `rushx build` (type-helpers) — green; type-test assertions gate the build
- [x] Full `rush build` — green across all 16 operations, including the `async-timers` consumer
- [x] Verified the `@ts-expect-error` assertions are live (a deliberately-wrong directive fails the build)