### PR TITLE
feat(type-helpers): export flattenMap

### DIFF
--- a/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-flatten-map_2026-06-06-01-19.json
+++ b/common/changes/@rhombus-toolkit/type-helpers/feat-type-helpers-flatten-map_2026-06-06-01-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Export flattenMap (type + runtime): flatten a DeepDictionary<Func> into a dot-keyed flat record",
+      "type": "minor",
+      "packageName": "@rhombus-toolkit/type-helpers"
+    }
+  ],
+  "packageName": "@rhombus-toolkit/type-helpers",
+  "email": "2511516+fnrhombus@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -203,6 +203,12 @@ importers:
       '@rushstack/heft':
         specifier: ~1.2.17
         version: 1.2.17(@types/node@25.9.1)
+      '@rushstack/heft-jest-plugin':
+        specifier: 2.0.6
+        version: 2.0.6(@rushstack/heft@1.2.17(@types/node@25.9.1))(@types/jest@30.0.0)(@types/node@25.9.1)(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       typescript:
         specifier: ~5.8.2
         version: 5.8.3

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "fab66530e83af20a5a85688c396a76c718b137cc",
+  "pnpmShrinkwrapHash": "f761f2c3f2e3d73e14eb0474a6380a07c7f36688",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/libraries/type-helpers/.npmignore
+++ b/libraries/type-helpers/.npmignore
@@ -6,3 +6,11 @@
 *.test.js.map
 *.test.d.ts
 *.test.d.ts.map
+
+# Runtime Jest suites (*.spec.ts) and the Jest config are dev-only too.
+*.spec.ts
+*.spec.js
+*.spec.js.map
+*.spec.d.ts
+*.spec.d.ts.map
+config/jest.config.json

--- a/libraries/type-helpers/config/jest.config.json
+++ b/libraries/type-helpers/config/jest.config.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@rushstack/heft-jest-plugin/includes/jest-web.config.json",
+
+    // The *.test.ts files in this package are type-level assertion suites compiled
+    // by `heft build`; their emitted JS contains bare `isAssignable;` expression
+    // statements that would throw ReferenceError under Jest. Runtime suites use the
+    // `.spec.ts` suffix so the two never collide.
+    "testMatch": ["<rootDir>/lib-commonjs/**/*.spec.js"]
+}

--- a/libraries/type-helpers/package.json
+++ b/libraries/type-helpers/package.json
@@ -1,28 +1,30 @@
 {
-  "name": "@rhombus-toolkit/type-helpers",
-  "version": "1.9.0",
-  "description": "",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/rhombus-toolkit/ts.git",
-    "directory": "libraries/type-helpers"
-  },
-  "main": "lib/index.js",
-  "types": "src/index.ts",
-  "sideEffects": false,
-  "scripts": {
-    "test": "heft test --clean",
-    "build": "heft build --clean",
-    "build:watch": "heft build"
-  },
-  "keywords": [],
-  "author": "Thomas Butler",
-  "dependencies": {
-    "@rhombus-toolkit/func": "workspace:*"
-  },
-  "devDependencies": {
-    "@rhombus-toolkit/heft-web-rig": "workspace:*",
-    "@rushstack/heft": "~1.2.17",
-    "typescript": "~5.8.2"
-  }
+    "name": "@rhombus-toolkit/type-helpers",
+    "version": "1.9.0",
+    "description": "",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/rhombus-toolkit/ts.git",
+        "directory": "libraries/type-helpers"
+    },
+    "main": "lib/index.js",
+    "types": "src/index.ts",
+    "sideEffects": false,
+    "scripts": {
+        "test": "heft test --clean",
+        "build": "heft build --clean",
+        "build:watch": "heft build"
+    },
+    "keywords": [],
+    "author": "Thomas Butler",
+    "dependencies": {
+        "@rhombus-toolkit/func": "workspace:*"
+    },
+    "devDependencies": {
+        "@rhombus-toolkit/heft-web-rig": "workspace:*",
+        "@rushstack/heft": "~1.2.17",
+        "@rushstack/heft-jest-plugin": "2.0.6",
+        "@types/jest": "30.0.0",
+        "typescript": "~5.8.2"
+    }
 }

--- a/libraries/type-helpers/src/flattenMap.spec.ts
+++ b/libraries/type-helpers/src/flattenMap.spec.ts
@@ -1,0 +1,66 @@
+import { flattenMap } from './flattenMap';
+
+describe('flattenMap (runtime)', () => {
+    it('passes a flat map through unchanged, preserving leaf identity', () => {
+        const a = (): void => undefined;
+        const b = (): void => undefined;
+        const result = flattenMap({ a, b } as any);
+
+        expect(Object.keys(result).sort()).toEqual(['a', 'b']);
+        expect((result as any).a).toBe(a);
+        expect((result as any).b).toBe(b);
+    });
+
+    it('flattens nested maps into dot-joined keys', () => {
+        const c = (): void => undefined;
+        const result = flattenMap({ b: { c } } as any);
+
+        expect(Object.keys(result)).toEqual(['b.c']);
+        expect((result as any)['b.c']).toBe(c);
+    });
+
+    it('flattens 3+ levels deep', () => {
+        const e = (): void => undefined;
+        const result = flattenMap({ a: { b: { d: { e } } } } as any);
+
+        expect(Object.keys(result)).toEqual(['a.b.d.e']);
+        expect((result as any)['a.b.d.e']).toBe(e);
+    });
+
+    it('handles mixed-depth siblings', () => {
+        const top = (): void => undefined;
+        const deep = (): void => undefined;
+        const result = flattenMap({ top, group: { nested: { deep } } } as any) as any;
+
+        expect(new Set(Object.keys(result))).toEqual(new Set(['top', 'group.nested.deep']));
+        expect(result.top).toBe(top);
+        expect(result['group.nested.deep']).toBe(deep);
+    });
+
+    it('returns an empty object for an empty map', () => {
+        const result = flattenMap({} as any);
+        expect(Object.keys(result)).toEqual([]);
+    });
+
+    it('contributes no keys for an empty nested object', () => {
+        const a = (): void => undefined;
+        const result = flattenMap({ a, empty: {} } as any) as any;
+
+        expect(Object.keys(result)).toEqual(['a']);
+        expect(result.a).toBe(a);
+        expect('empty' in result).toBe(false);
+    });
+
+    it('produces a plain object with only the expected own keys', () => {
+        const a = (): void => undefined;
+        const c = (): void => undefined;
+        const result = flattenMap({ a, b: { c } } as any) as any;
+
+        // own enumerable keys only — no inherited / polluted keys
+        expect(Object.keys(result).sort()).toEqual(['a', 'b.c']);
+        // not constructed from a polluting prototype
+        expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+        expect(result.__proto__).toBe(Object.prototype);
+        expect(result.constructor).toBe(Object);
+    });
+});

--- a/libraries/type-helpers/src/flattenMap.test.ts
+++ b/libraries/type-helpers/src/flattenMap.test.ts
@@ -1,0 +1,49 @@
+import { flattenMap } from './index';
+import { Func } from '@rhombus-toolkit/func';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+// Func is contravariant on its Args parameter (`in Args`), so a leaf typed with
+// specific args (e.g. Func<[number], void>) is NOT assignable to the bare Func
+// the DeepDictionary<Func> constraint requires. Leaves therefore keep Args as
+// any[] and vary the covariant Return to stay distinguishable.
+
+namespace shallowTest {
+    type Subject = flattenMap<{
+        a: Func<any[], number>;
+        b: { c: Func<any[], string> };
+    }>;
+    type Expected = {
+        a: Func<any[], number>;
+        'b.c': Func<any[], string>;
+    };
+
+    // @ts-expect-no-error
+    isAssignable<Subject, Expected>;
+    // @ts-expect-no-error
+    isAssignable<Expected, Subject>;
+
+    // wrong key
+    // @ts-expect-error
+    isAssignable<Subject, { a: Func<any[], number>; 'b.d': Func<any[], string> }>;
+    // wrong leaf return type
+    // @ts-expect-error
+    isAssignable<Subject, { a: Func<any[], string>; 'b.c': Func<any[], string> }>;
+}
+
+namespace deepTest {
+    type Subject = flattenMap<{
+        a: { b: { c: Func<any[], number> } };
+        x: Func<any[], void>;
+    }>;
+    type Expected = {
+        'a.b.c': Func<any[], number>;
+        x: Func<any[], void>;
+    };
+
+    // @ts-expect-no-error
+    isAssignable<Subject, Expected>;
+    // @ts-expect-no-error
+    isAssignable<Expected, Subject>;
+}

--- a/libraries/type-helpers/src/flattenMap.ts
+++ b/libraries/type-helpers/src/flattenMap.ts
@@ -1,0 +1,36 @@
+import { Func } from '@rhombus-toolkit/func';
+import { Inc } from './counter';
+import { DeepDictionary, DeepDictionaryItem } from './deep-record';
+import { fromEntries } from './obj';
+type _flattenMap<T extends DeepDictionaryItem<Func>, prefix extends string = '', CurrentDepth extends number = 0> =
+    CurrentDepth extends 10 ? never
+    : T extends DeepDictionary<Func> ?
+        {
+            [K in keyof T]: _flattenMap<
+                T[K],
+                prefix extends '' ? string & K : `${prefix}.${string & K}`,
+                Inc<CurrentDepth>
+            >;
+        }[keyof T]
+    :   [prefix, T];
+
+export type flattenMap<T extends DeepDictionary<Func>> = fromEntries<_flattenMap<T>>;
+export function flattenMap<T extends DeepDictionary<Func>>(map: T): flattenMap<T> {
+    const result: any = {};
+    const stack = Object.entries(map);
+    while (stack.length) {
+        const [prefix, mapOrFun] = stack.pop()!;
+        if (typeof mapOrFun === 'function') {
+            result[prefix] = mapOrFun;
+        } else {
+            for (const [key, p] of Object.entries(mapOrFun)) {
+                stack.push([join(prefix, key), p]);
+            }
+        }
+    }
+    return result;
+}
+
+function join(...args: string[]): string {
+    return args.filter(Boolean).join('.');
+}

--- a/libraries/type-helpers/src/index.ts
+++ b/libraries/type-helpers/src/index.ts
@@ -4,7 +4,7 @@ export * from './CheapRingBuffer';
 export * from './counter';
 // export * from './curry';
 export * from './deep-record';
-// export * from './flattenMap';
+export * from './flattenMap';
 export * from './identity';
 // export * from './Lazy';
 export * from './node-callback-to-async';

--- a/libraries/type-helpers/tsconfig.json
+++ b/libraries/type-helpers/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "@rhombus-toolkit/heft-web-rig/profiles/library/tsconfig-base.json",
-  "compilerOptions": {
-    "outDir": "lib"
-  },
-  "exclude": [
-    "on-ice"
-  ]
+    "extends": "@rhombus-toolkit/heft-web-rig/profiles/library/tsconfig-base.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "types": ["jest"]
+    },
+    "exclude": ["on-ice"]
 }


### PR DESCRIPTION
## Summary

- Restore `flattenMap` (type + runtime) from the 1.3.1 release as a real export of `@rhombus-toolkit/type-helpers`. It flattens a `DeepDictionary<Func>` into a dot-keyed flat record.
- One modernization over 1.3.1: the deprecated `Cast<K, string>` (deprecated in #273) is replaced with the equivalent intersection `string & K`; the now-unneeded `Cast` import is dropped.
- `on-ice/flattenMap.ts` is untouched (tsconfig excludes it).
- Wire up Jest for this package (the first one here with runtime tests) and add a full runtime suite for `flattenMap`.

## Test infrastructure landed

The `heft-web-rig` already provided the jest plugin, the jsdom env and `@types/jest@30`; the only missing piece was `config/jest.config.json`. Added that plus `@rushstack/heft-jest-plugin@2.0.6` + `@types/jest@30.0.0` devDeps and `"types": ["jest"]` in tsconfig so the Jest globals resolve. No toolchain/rig version bump — everything stays within the rig's locked versions.

Hazard handled: the existing `*.test.ts` files are type-level assertion suites whose compiled JS emits bare `isAssignable;` expression statements that would `ReferenceError` under Jest. `testMatch` is scoped to `lib-commonjs/**/*.spec.js`, so runtime suites use the `.spec.ts` suffix and never collide with the type-test gate. Verified the type assertions remain live (a flipped `@ts-expect-error` still fails `heft build`).

## Test plan

- [x] Full `rush build` — green across all 14 build operations (consumers included)
- [x] `rushx test` (type-helpers) — `heft build` green + Jest 7/7 passing
- [x] Type-test assertions confirmed still gating the build after the Jest restructure

CI runs `rush rebuild`, which does not run the test phase; the runtime suite runs via `rushx test` locally and was run green before pushing. Runtime coverage: flat pass-through with leaf-identity, nested dotted keys, 3+ levels deep, mixed-depth siblings, empty map, empty nested object contributing no keys, and a plain-prototype / expected-own-keys check.