### PR TITLE
fix(type-helpers): Take, Skip and Subtract returned their own input

### DIFF
--- a/libraries/type-helpers/src/array.d.ts
+++ b/libraries/type-helpers/src/array.d.ts
@@ -3,32 +3,26 @@ import { Cast } from './cast';
 /**
  * the first element
  */
-export type Head<T extends any[]> =
-    T extends [infer R, ...any] ? R : never;
+export type Head<T extends any[]> = T extends [infer R, ...any] ? R : never;
 
 /**
  * all but the first element
  */
-export type Tail<T extends any[]> =
-    T extends [any, ...infer R] ? R : never;
+export type Tail<T extends any[]> = T extends [any, ...infer R] ? R : never;
 
 /**
  * all but the last element
- */;
-export type Body<T extends any[]> =
-    T extends [...infer R, any] ? R : never;
+ */
+export type Body<T extends any[]> = T extends [...infer R, any] ? R : never;
 /**
  * the last element
  */
-export type Last<T extends any[]> =
-    T extends [...any, infer R] ? R : never;
-
+export type Last<T extends any[]> = T extends [...any, infer R] ? R : never;
 
 /**
  * the length of the list
  */
 export type Length<T extends any[]> = Cast<T['length'], number>;
-
 
 /**
  * Moves Values from the front of the right away to the end of the left.
@@ -36,41 +30,45 @@ export type Length<T extends any[]> = Cast<T['length'], number>;
  * ShiftLeft<[0,1,2],[3,4,5,6],2> => [[0,1,2,3,4],[5,6]]]
  */
 type ShiftLeft<left extends any[], right extends any[], count extends number> =
-    Length<left> extends count ? [left, right] :
-    right extends [] ? [left, right] :
-    ShiftLeft<[...left, Head<right>], Tail<right>, count>;
-
-
-
+    Length<left> extends count ? [left, right]
+    : right extends [] ? [left, right]
+    : ShiftLeft<[...left, Head<right>], Tail<right>, count>;
 
 /**
  * SplitArray<[0,1,2,3,4,5,6,7,8], 3> => [[0,1,2],[3,4,5,6,7,8]]
  */
-export type SplitArray<array extends any[], count extends number> =
-    ShiftLeft<[], array, count>;
-
+export type SplitArray<array extends any[], count extends number> = ShiftLeft<[], array, count>;
 
 /**
  * Slice<[0,1,2,3,4,5,6,7,8], 2, 3> => [2,3,4]
  */
-export type Slice<array extends any[], start extends number = 0, length extends number = Length<array>> =
-    Take<length, Skip<start, array>>;
+export type Slice<array extends any[], start extends number = 0, length extends number = Length<array>> = Take<
+    length,
+    Skip<start, array>
+>;
 
 /**
  * Take<2, [0,1,2,3,4]> => [0,1]
+ *
+ * @remarks
+ * The fallback is `any[]`, not `T`. `Cast<V, F>` yields `F` whenever `V` is not
+ * assignable to it, and a prefix is never assignable to the array it came from
+ * once arity is fixed -- so a fallback of `T` fired on every call and handed
+ * back the whole input. The cast is here to state array-ness for a conditional
+ * the checker cannot evaluate while `N` and `T` are parameters; `any[]` is what
+ * that assertion actually means, and it should be unreachable.
  */
-export type Take<N extends number, T extends any[]> =
-    Cast<SplitArray<T, N>[0], T>;
+export type Take<N extends number, T extends any[]> = Cast<SplitArray<T, N>[0], any[]>;
 
 /**
  * Skip<2, [0,1,2,3,4]> => [2,3,4]
+ *
+ * @remarks
+ * Same fallback correction as {@link Take}.
  */
-export type Skip<N extends number, T extends any[]> =
-    Cast<SplitArray<T, N>[1], T>;
+export type Skip<N extends number, T extends any[]> = Cast<SplitArray<T, N>[1], any[]>;
 
 /**
  * PartialList<[0,1,2,3]> => [0,1,2,3] | [0,1,2] | [0,1] | [0] | []
  */
-export type PartialList<T extends any[]> = T | (
-    T extends [...infer R, any] ? PartialList<R> : []
-);
+export type PartialList<T extends any[]> = T | (T extends [...infer R, any] ? PartialList<R> : []);

--- a/libraries/type-helpers/src/array.test.ts
+++ b/libraries/type-helpers/src/array.test.ts
@@ -1,0 +1,107 @@
+import { Body, Head, Last, Length, Skip, Slice, SplitArray, Tail, Take } from './array';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+type Five = [0, 1, 2, 3, 4];
+
+namespace splitArrayTest {
+    type Subject = SplitArray<Five, 2>;
+    type Expected = [[0, 1], [2, 3, 4]];
+
+    // @ts-expect-no-error
+    isAssignable<Subject, Expected>;
+    // @ts-expect-no-error
+    isAssignable<Expected, Subject>;
+}
+
+/**
+ * The regression. `Take` used `T` as its `Cast` fallback, and a prefix is never
+ * assignable to the array it came from, so the fallback fired every call and the
+ * whole input came back.
+ */
+namespace takeTest {
+    type Subject = Take<2, Five>;
+
+    // @ts-expect-no-error
+    isAssignable<Subject, [0, 1]>;
+    // @ts-expect-no-error
+    isAssignable<[0, 1], Subject>;
+
+    // the old broken behaviour: the entire input array
+    // @ts-expect-error
+    isAssignable<Subject, Five>;
+}
+
+namespace takeEdgesTest {
+    // @ts-expect-no-error
+    isAssignable<Take<0, Five>, []>;
+    // @ts-expect-no-error
+    isAssignable<[], Take<0, Five>>;
+    // @ts-expect-no-error
+    isAssignable<Take<5, Five>, Five>;
+    // @ts-expect-no-error
+    isAssignable<Five, Take<5, Five>>;
+}
+
+namespace skipTest {
+    type Subject = Skip<2, Five>;
+
+    // @ts-expect-no-error
+    isAssignable<Subject, [2, 3, 4]>;
+    // @ts-expect-no-error
+    isAssignable<[2, 3, 4], Subject>;
+
+    // the old broken behaviour
+    // @ts-expect-error
+    isAssignable<Subject, Five>;
+}
+
+namespace skipEdgesTest {
+    // @ts-expect-no-error
+    isAssignable<Skip<0, Five>, Five>;
+    // @ts-expect-no-error
+    isAssignable<Five, Skip<0, Five>>;
+    // @ts-expect-no-error
+    isAssignable<Skip<5, Five>, []>;
+    // @ts-expect-no-error
+    isAssignable<[], Skip<5, Five>>;
+}
+
+namespace sliceTest {
+    type Subject = Slice<Five, 1, 3>;
+
+    // @ts-expect-no-error
+    isAssignable<Subject, [1, 2, 3]>;
+    // @ts-expect-no-error
+    isAssignable<[1, 2, 3], Subject>;
+}
+
+/**
+ * `Take` and `Skip` must still satisfy an `any[]` constraint while `N` and `T`
+ * are parameters -- that is what the `Cast` is for, and what `Curry` relies on.
+ */
+namespace stillSatisfiesArrayConstraintTest {
+    type NeedsArray<T extends any[]> = T;
+
+    type TakeStaysAnArray<N extends number, T extends any[]> = NeedsArray<Take<N, T>>;
+    type SkipStaysAnArray<N extends number, T extends any[]> = NeedsArray<Skip<N, T>>;
+
+    // @ts-expect-no-error
+    isAssignable<TakeStaysAnArray<2, Five>, [0, 1]>;
+    // @ts-expect-no-error
+    isAssignable<SkipStaysAnArray<2, Five>, [2, 3, 4]>;
+}
+
+namespace headTailBodyLastTest {
+    // @ts-expect-no-error
+    isAssignable<Head<Five>, 0>;
+    // @ts-expect-no-error
+    isAssignable<Last<Five>, 4>;
+    // @ts-expect-no-error
+    isAssignable<Tail<Five>, [1, 2, 3, 4]>;
+    // @ts-expect-no-error
+    isAssignable<Body<Five>, [0, 1, 2, 3]>;
+    // @ts-expect-no-error
+    isAssignable<Length<Five>, 5>;
+}

--- a/libraries/type-helpers/src/counter.alt.d.ts
+++ b/libraries/type-helpers/src/counter.alt.d.ts
@@ -1,39 +1,51 @@
 import { Length, Skip, Tail } from './array';
 import { Cast } from './cast';
 
-
 type CounterArray = any[];
 type Next<I extends CounterArray> = [never, ...I];
-
 
 type Prev<I extends CounterArray> = Tail<I>;
 
 type ExpandArrayToLength<counter extends CounterArray, length extends number> =
-    Length<counter> extends length ? counter :
-    ExpandArrayToLength<[never, ...counter], length>;
+    Length<counter> extends length ? counter : ExpandArrayToLength<[never, ...counter], length>;
 
 // type _Counter<length extends number, counter extends CounterArray = []> =
 //     Length<counter> extends length ? counter :
 //     _Counter<length, Next<counter>>;
 
 type _Counter<length extends number> =
-    length extends 0 ? [] :
-    length extends 1 ? [never] :
-    ExpandArrayToLength<[], length>;
+    length extends 0 ? []
+    : length extends 1 ? [never]
+    : ExpandArrayToLength<[], length>;
 type Counter<length extends number> = Cast<_Counter<length>, CounterArray>;
 
 export type Store<value extends number> = Counter<value>;
 export type Inc<N extends number> = Length<Next<Counter<N>>>;
 export type Dec<N extends number> = Length<Prev<Counter<N>>>;
 
-export type Add<X extends number, Y extends number> =
-    Length<[...Counter<X>, ...Counter<Y>]>;
+export type Add<X extends number, Y extends number> = Length<[...Counter<X>, ...Counter<Y>]>;
 
-export type Subtract<X extends number, Y extends number> =
-    Length<Skip<Y, Counter<X>>>;
+/**
+ * `X - Y`, clamped at zero.
+ *
+ * @remarks
+ * Peels a cell from each side rather than routing through {@link Skip}. Going
+ * through `Skip` relates its deferred result against `Length`'s `T extends any[]`
+ * bound across `Counter<X>`'s unbounded recursion, which fails at this
+ * declaration with "Excessive stack depth" the moment this file is type-checked
+ * rather than skipped as an ambient declaration.
+ *
+ * Clamping is not a choice: a tuple has no negative length, so the subtrahend
+ * running out first is the only representable answer.
+ */
+export type Subtract<X extends number, Y extends number> = Length<_Subtract<Counter<X>, Counter<Y>>>;
+type _Subtract<X extends CounterArray, Y extends CounterArray> =
+    Y extends [any, ...infer YRest] ?
+        X extends [any, ...infer XRest] ?
+            _Subtract<XRest, YRest>
+        :   []
+    :   X;
 
 export type Multiply<X extends number, Y extends number> = Length<_Mult<_Counter<X>, _Counter<Y>, []>>;
 type _Mult<X extends any[], Y extends any[], R extends any[]> =
-    Length<Y> extends 0 ? R :
-    _Mult<X, Prev<Y>, [...R, ...X]>;
-
+    Length<Y> extends 0 ? R : _Mult<X, Prev<Y>, [...R, ...X]>;

--- a/libraries/type-helpers/src/counter.alt.test.ts
+++ b/libraries/type-helpers/src/counter.alt.test.ts
@@ -1,0 +1,63 @@
+import { Add, Dec, Inc, Multiply, Subtract } from './counter.alt';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+declare function isAssignable<TExpected>(actual?: TExpected): void;
+
+namespace incDecTest {
+    // @ts-expect-no-error
+    isAssignable<Inc<0>, 1>;
+    // @ts-expect-no-error
+    isAssignable<Inc<5>, 6>;
+    // @ts-expect-no-error
+    isAssignable<Dec<5>, 4>;
+    // @ts-expect-no-error
+    isAssignable<Dec<1>, 0>;
+}
+
+namespace addTest {
+    // @ts-expect-no-error
+    isAssignable<Add<3, 4>, 7>;
+    // @ts-expect-no-error
+    isAssignable<Add<0, 0>, 0>;
+    // @ts-expect-no-error
+    isAssignable<Add<9, 0>, 9>;
+}
+
+/**
+ * The regression. `Subtract` routed through `Skip`, so it inherited `Skip`'s
+ * broken fallback and returned `X` unchanged -- `Subtract<5, 2>` was `5`.
+ */
+namespace subtractTest {
+    // @ts-expect-no-error
+    isAssignable<Subtract<5, 2>, 3>;
+    // @ts-expect-no-error
+    isAssignable<3, Subtract<5, 2>>;
+
+    // the old broken behaviour: the minuend, untouched
+    // @ts-expect-error
+    isAssignable<Subtract<5, 2>, 5>;
+
+    // @ts-expect-no-error
+    isAssignable<Subtract<10, 10>, 0>;
+    // @ts-expect-no-error
+    isAssignable<Subtract<7, 0>, 7>;
+    // @ts-expect-no-error
+    isAssignable<Subtract<0, 0>, 0>;
+}
+
+/** A tuple has no negative length, so the subtrahend running out first is the only representable answer. */
+namespace subtractClampsTest {
+    // @ts-expect-no-error
+    isAssignable<Subtract<2, 5>, 0>;
+    // @ts-expect-no-error
+    isAssignable<0, Subtract<2, 5>>;
+}
+
+namespace multiplyTest {
+    // @ts-expect-no-error
+    isAssignable<Multiply<3, 4>, 12>;
+    // @ts-expect-no-error
+    isAssignable<Multiply<0, 5>, 0>;
+    // @ts-expect-no-error
+    isAssignable<Multiply<5, 1>, 5>;
+}


### PR DESCRIPTION
Three type-level bugs in `type-helpers`, all invisible today because `skipLibCheck: true` means these `.d.ts` bodies are never checked. Everything below verified against pinned tsc 5.8.3.

## `Take` / `Skip` returned the whole input array

`Cast<V, F>` yields `F` whenever `V` is not assignable to it. Both passed the input array as that fallback:

```ts
export type Take<N extends number, T extends any[]> = Cast<SplitArray<T, N>[0], T>;
//                                                                             ^ the input
```

A prefix is never assignable to the array it came from once arity is fixed, so the fallback fired on **every** call:

```
Take<2, [0,1,2,3,4]>  ->  [0,1,2,3,4]     documented as [0,1]
Skip<2, [0,1,2,3,4]>  ->  [0,1,2,3,4]     documented as [2,3,4]
SplitArray<[0,1,2,3,4], 2>  ->  [[0,1],[2,3,4]]     the split itself was always fine
```

The cast is there to state array-ness for a conditional the checker cannot evaluate while `N` and `T` are still parameters. `any[]` is what that assertion actually means, and it should be unreachable. The fixed form still satisfies an `any[]` constraint in generic position — the property `Curry` depends on, covered by a test.

## `Subtract` was wrong, and the mechanical fix breaks it differently

`Subtract` routed through `Skip`, so it inherited the bug — `Subtract<5, 2>` was `5`. But simply fixing `Skip` does not repair it. Routing through `Skip` relates its deferred result against `Length`'s `T extends any[]` bound across `Counter<X>`'s unbounded recursion, which fails **at the declaration** as soon as the file is type-checked rather than skipped as an ambient declaration:

```
counter.alt.ts(33,5): error TS2321: Excessive stack depth comparing types
  'ShiftLeft<[], Cast<_Counter<X>, CounterArray>, Y>[1]' and 'any[]'.
```

That matters beyond this PR: the reorg promotes these to checked `.ts`, at which point the naive fix stops compiling. So `Subtract` now peels a cell from each side directly:

```ts
type _Subtract<X extends CounterArray, Y extends CounterArray> =
    Y extends [any, ...infer YRest] ?
        X extends [any, ...infer XRest] ? _Subtract<XRest, YRest> : []
    :   X;
```

It clamps at zero, which is not a design choice — a tuple has no negative length, so the subtrahend running out first is the only representable answer.

## A stray `;` detached `Body`'s doc comment

`array.d.ts` had `*/;` after the "all but the last element" comment. That is a live `TS1036` (statements are not allowed in ambient contexts) suppressed by `skipLibCheck`, and it left `Body` with no intellisense.

## Tests

New `array.test.ts` and `counter.alt.test.ts` in the repo's existing `isAssignable` style. Both directions asserted, and the **old broken results are pinned with `@ts-expect-error`**, so a regression is caught rather than silently returned:

```ts
// the old broken behaviour: the entire input array
// @ts-expect-error
isAssignable<Take<2, Five>, Five>;
```

The whole set compiles under `skipLibCheck: false`, so the declaration bodies are genuinely checked — and since an unfired `@ts-expect-error` is itself an error, every negative assertion is proven to fire.

Coverage: `SplitArray`, `Take`/`Skip` including both zero and full-length edges, `Slice`, the generic-position `any[]` constraint, `Head`/`Tail`/`Body`/`Last`/`Length`, and `Inc`/`Dec`/`Add`/`Subtract`/`Multiply` including the clamp.

## Notes

- `Curry` is downstream of `Skip` and has been non-functional — `_CurryBasic` recurses on `Skip<Length<T>, TArgs>`, which never shrank. This is its prerequisite.
- Independent of the toolchain PR; no file overlap.
