### PR TITLE
build(repo): publish pipeline (release-please + staged OIDC publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+# Publish pipeline: release-please (independent per-package versioning) ->
+# pnpm pack -> npm staged publish (OIDC trusted publishing).
+#
+# WIRED BUT INERT. All 11 publishable packages' npm Trusted Publisher points at
+# THIS file by name -- npm allows exactly one trusted publisher per package, so
+# renaming this workflow means redoing 11 packages by hand, each behind a
+# security-key tap. Never rename it.
+#
+# Two independent gates sit between a merge to main and a live npm release:
+#
+#   1. The `publish` job only runs once the `PUBLISHING_ENABLED` repository
+#      variable is the string "true". It does not exist yet, so `publish`
+#      cannot run even though its trigger is otherwise live -- this is
+#      deliberate: the pipeline is fully wired, publishing is not switched on.
+#   2. Even once enabled, this workflow only STAGES each release (`npm stage
+#      publish`), never publishes it directly. A staged package sits pending
+#      until a human runs `npm stage approve <id>`, which requires 2FA -- OIDC
+#      trust tokens can stage but cannot approve (verified against npm's
+#      staged-publish docs, npm/cli#9201). That is what makes an 11-package
+#      release atomic: a mid-sequence failure here leaves everything staged so
+#      far merely pending, never live, so there is no partial release to undo.
+#
+# The `release-please` job itself is NOT gated behind `PUBLISHING_ENABLED` --
+# opening/updating a release PR touches no registry and is safe to run from
+# day one, so the version/changelog proposals are reviewable before publishing
+# is ever switched on.
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Opens/updates one release PR per package (independent versions --
+  # `separate-pull-requests: true` in release-please-config.json, unlike a
+  # lockstep monorepo's single combined PR). When a release PR is merged, this
+  # step instead tags the release and reports it via `releases_created`.
+  release-please:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      releases-created: ${{ steps.release.outputs.releases_created }}
+    steps:
+      # release-please's own PRs need a PAT, not GITHUB_TOKEN: PRs opened with
+      # the default token don't trigger downstream workflow runs (GitHub
+      # suppresses that to prevent recursive workflow triggering), which would
+      # leave every release PR stuck waiting on a `verify` run that never
+      # starts. Until the secret is set, no-op cleanly instead of failing CI.
+      - name: Detect release automation token
+        id: token_check
+        env:
+          AUTOMERGE_PAT: ${{ secrets.AUTOMERGE_PAT }}
+        run: |
+          if [ -n "$AUTOMERGE_PAT" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::AUTOMERGE_PAT not set -- skipping release-please. Set the secret to enable release PRs."
+          fi
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        if: steps.token_check.outputs.present == 'true'
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.AUTOMERGE_PAT }}
+
+  # Fires only once a release-please PR has actually merged (releases-created)
+  # AND publishing is deliberately switched on. Builds every package, then
+  # walks scripts/publish-libraries.ts's topological order staging each one.
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.releases-created == 'true' && vars.PUBLISHING_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Installs bun + pnpm at the versions mise.toml pins -- unlike std/ioc,
+      # this repo's mise.toml already pins pnpm (10.34.4), so no separate
+      # `npm install -g pnpm` step is needed here.
+      - uses: jdx/mise-action@v2
+
+      # For the OIDC-aware `.npmrc` `registry-url` writes -- this is the actual
+      # mechanism trusted publishing authenticates through, not just a node
+      # runtime. mise.toml also pins node 24; this is about the npm CLI + auth
+      # wiring, not the runtime.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      # `npm stage` needs a newer npm than plain OIDC provenance does: verified
+      # against npm/cli#9201 (merged 2026-05-20), first shipped in npm 11.16.0.
+      - name: Upgrade npm (staged publishing needs npm >= 11.16.0)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Stage-publish released packages
+        run: bun scripts/publish-libraries.ts --publish

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,13 @@
+{
+  "libraries/async-timers": "1.4.4",
+  "libraries/case-converter": "1.3.2",
+  "libraries/defer": "1.4.2",
+  "libraries/fetch": "1.3.9",
+  "libraries/func": "3.6.0",
+  "libraries/kinda-weak-map": "1.4.2",
+  "libraries/proxy-base": "1.0.0",
+  "libraries/set-immediate": "1.3.2",
+  "libraries/singleton": "1.3.4",
+  "libraries/type-guards": "1.3.4",
+  "libraries/type-helpers": "2.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "bun scripts/build-all.ts",
     "test": "bun --filter '*' test",
-    "lint": "bun --filter '*' lint",
+    "lint": "bun --filter '*' lint && bun scripts/derive-publish-config.ts --check",
     "format": "dprint fmt",
     "format:check": "dprint check",
     "knip": "knip --tsConfig tsconfig.knip.json --no-exit-code",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": true,
+  "include-v-in-tag": true,
+  "separate-pull-requests": true,
+  "packages": {
+    "libraries/async-timers": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/async-timers",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/case-converter": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/case-converter",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/defer": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/defer",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/fetch": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/fetch",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/func": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/func",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/kinda-weak-map": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/kinda-weak-map",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/proxy-base": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/proxy-base",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/set-immediate": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/set-immediate",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/singleton": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/singleton",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/type-guards": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/type-guards",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "libraries/type-helpers": {
+      "release-type": "node",
+      "package-name": "@rhombus-toolkit/type-helpers",
+      "changelog-path": "CHANGELOG.md"
+    }
+  },
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "refactor", "section": "Refactoring", "hidden": true },
+    { "type": "build", "section": "Build", "hidden": true },
+    { "type": "ci", "section": "CI", "hidden": true },
+    { "type": "chore", "section": "Chores", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "style", "section": "Style", "hidden": true }
+  ]
+}

--- a/scripts/derive-publish-config.ts
+++ b/scripts/derive-publish-config.ts
@@ -1,0 +1,229 @@
+// Derives every publishable library's `publishConfig` from its DEV `exports`,
+// adapted from std's script of the same name. Matters more here than in std:
+// the types package gains four subpaths in P3 (array/string/generic/guards),
+// and hand-maintaining publishConfig for each one will drift silently.
+//
+// The derivation rule (confirmed against every hand-authored manifest in this
+// repo today):
+//
+//   publishConfig.exports = exports, with two transforms:
+//     1. SCRUB     -- any white-box subpath (`./tokens/*`, `./private/*`) is
+//                     dropped. No package here declares one yet, but the
+//                     mechanism carries forward for when one does.
+//     2. DIST-SWAP -- each surviving subpath collapses its dev-resolution
+//                     conditions to the published trio, in canonical order:
+//                       types   <- the dev `types` condition (or `source`/
+//                                  `default` as a fallback), dist-swapped
+//                       import  <- present iff the dev entry has an `import`
+//                                  condition (a runtime lib)
+//                       default <- the dev `default` (or `import`/`bun`)
+//                                  condition, dist-swapped
+//                     The dev-only conditions (`source`, `bun`) are dropped --
+//                     published consumers resolve through import/default/types
+//                     only. In this repo's manifests `import`/`default`/`types`
+//                     already point at `./dist/bundle/*` (only `source` points
+//                     at raw `./src/*.ts`, for the editor's benefit -- see
+//                     tsconfig.editor.json's `source` condition), so the swap
+//                     is a no-op there and only bites the `source` fallback path.
+//
+//   Top-level publishConfig.main/module/types are the same dist-swap of the
+//   top-level fields, emitted only for the fields the package actually declares
+//   (a types-only package like func has no `main`).
+//
+//   Non-derived publishConfig fields (`access`, `provenance`) are preserved
+//   verbatim -- they're publish policy, not derivable from `exports`.
+//
+// NON_DERIVABLE holds package names whose publishConfig is a deliberate
+// semantic reshape of `exports`, not a mechanical dist-swap (std's
+// @rhombus-std/config is the precedent). Empty today -- nothing in this repo
+// needs it, but the escape hatch stays so a future reshape doesn't have to
+// fight this script.
+//
+// Modes:
+//   --check   exit non-zero listing packages whose publishConfig drifts from
+//             the derived form (structural compare -- formatting-immune).
+//   --write   rewrite publishConfig in place for any drifting package.
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+
+const ROOT = `${import.meta.dir}/..`;
+const LIBS = `${ROOT}/libraries`;
+
+const NON_DERIVABLE = new Set<string>();
+
+interface Conditions {
+  readonly [condition: string]: string;
+}
+type ExportEntry = string | Conditions;
+
+interface Manifest {
+  readonly name: string;
+  readonly private?: boolean;
+  readonly main?: string;
+  readonly module?: string;
+  readonly types?: string;
+  readonly exports?: Record<string, ExportEntry>;
+  readonly publishConfig?: Record<string, unknown>;
+  readonly rhombusBuild?: { readonly typesOnly?: boolean; };
+}
+
+/** True for a white-box seam subpath dropped from the published surface. Both
+ * halves are dev-only: `./tokens/*` (a source token surface) and `./private/*`
+ * (a built lowered runtime) -- std's convention, unused here so far. */
+function isInternal(subpath: string): boolean {
+  return subpath.startsWith('./tokens/') || subpath.startsWith('./private/');
+}
+
+/**
+ * Swap a dev path to its published dist target -- `./dist/bundle/` is where
+ * build-lib.ts emits:
+ *   kind 'js'  -> `./dist/bundle/<name>.js`   (runtime bundle)
+ *   kind 'dts' -> `./dist/bundle/<name>.d.ts` (rolled declarations)
+ * Idempotent: a value already under `./dist/bundle/` only has its extension
+ * retargeted, which is the common case in this repo (see header comment).
+ */
+function toDist(path: string, kind: 'js' | 'dts'): string {
+  const inDist = path.replace(/^\.\/src\//, './dist/bundle/');
+  const ext = kind === 'dts' ? '.d.ts' : '.js';
+  return inDist.replace(/\.(d\.ts|ts|js)$/, ext);
+}
+
+/** A package with no `.js` anywhere in its `.` conditions ships declarations only. */
+function isTypesOnly(manifest: Manifest): boolean {
+  if (manifest.rhombusBuild?.typesOnly) {
+    return true;
+  }
+  const dot = manifest.exports?.['.'];
+  if (dot === undefined || typeof dot === 'string') {
+    return false;
+  }
+  return !Object.values(dot).some((value) => value.endsWith('.js'));
+}
+
+/** The published conditions trio for one surviving subpath (the dist-swap). */
+function derivePublishedConditions(conditions: Conditions, typesOnly: boolean): Conditions {
+  const typesSource = conditions.types ?? conditions.source ?? conditions.default;
+  const out: Record<string, string> = {};
+  out.types = toDist(typesSource, 'dts');
+  if (conditions.import !== undefined) {
+    out.import = toDist(conditions.import, 'js');
+  }
+  const defaultSource = conditions.default ?? conditions.import ?? conditions.bun;
+  out.default = toDist(defaultSource, typesOnly ? 'dts' : 'js');
+  return out;
+}
+
+/** The derived `publishConfig.exports` for a whole manifest (scrub + dist-swap). */
+function derivePublishExports(manifest: Manifest): Record<string, ExportEntry> {
+  const typesOnly = isTypesOnly(manifest);
+  const out: Record<string, ExportEntry> = {};
+  for (const [subpath, entry] of Object.entries(manifest.exports ?? {})) {
+    if (isInternal(subpath)) {
+      continue;
+    }
+    if (typeof entry === 'string') {
+      out[subpath] = entry;
+      continue;
+    }
+    out[subpath] = derivePublishedConditions(entry, typesOnly);
+  }
+  return out;
+}
+
+/** The full derived publishConfig: preserves policy fields, replaces the derived ones. */
+function derivePublishConfig(manifest: Manifest): Record<string, unknown> {
+  const existing = manifest.publishConfig ?? {};
+  const derived: Record<string, unknown> = { ...existing };
+  if (manifest.main !== undefined) {
+    derived.main = toDist(manifest.main, 'js');
+  }
+  if (manifest.module !== undefined) {
+    derived.module = toDist(manifest.module, 'js');
+  }
+  if (manifest.types !== undefined) {
+    derived.types = toDist(manifest.types, 'dts');
+  }
+  derived.exports = derivePublishExports(manifest);
+  return derived;
+}
+
+interface Lib {
+  readonly name: string;
+  readonly file: string;
+  readonly manifest: Manifest;
+}
+
+/** Every publishable library: a `publishConfig` and not marked private. */
+function discover(): Lib[] {
+  const libs: Lib[] = [];
+  for (const dir of readdirSync(LIBS)) {
+    const file = `${LIBS}/${dir}/package.json`;
+    let raw: string;
+    try {
+      raw = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const manifest = JSON.parse(raw) as Manifest;
+    if (manifest.private || manifest.publishConfig === undefined) {
+      continue;
+    }
+    libs.push({ name: manifest.name, file, manifest });
+  }
+  return libs.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Structural (formatting-immune) equality via canonical JSON. */
+function equal(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function main(): void {
+  const mode = process.argv[2];
+  if (mode !== '--check' && mode !== '--write') {
+    console.error('usage: derive-publish-config.ts --check | --write');
+    process.exit(2);
+  }
+
+  const drifted: string[] = [];
+  const written: string[] = [];
+
+  for (const lib of discover()) {
+    if (NON_DERIVABLE.has(lib.name)) {
+      continue;
+    }
+    const derived = derivePublishConfig(lib.manifest);
+    if (equal(derived, lib.manifest.publishConfig)) {
+      continue;
+    }
+    drifted.push(lib.name);
+    if (mode === '--write') {
+      const next = { ...lib.manifest, publishConfig: derived };
+      writeFileSync(lib.file, `${JSON.stringify(next, null, 2)}\n`);
+      written.push(lib.name);
+    }
+  }
+
+  if (mode === '--check') {
+    if (drifted.length === 0) {
+      console.log('publishConfig is in sync with exports for every publishable library.');
+      return;
+    }
+    console.error('publishConfig drift (run `bun scripts/derive-publish-config.ts --write`):');
+    for (const name of drifted) {
+      console.error(`  - ${name}`);
+    }
+    process.exit(1);
+  }
+
+  if (written.length === 0) {
+    console.log('No drift -- nothing rewritten.');
+    return;
+  }
+  console.log(`Rewrote publishConfig for ${written.length} package(s):`);
+  for (const name of written) {
+    console.log(`  - ${name}`);
+  }
+}
+
+main();

--- a/scripts/publish-libraries.ts
+++ b/scripts/publish-libraries.ts
@@ -1,0 +1,176 @@
+// Topological publish helper for the @rhombus-toolkit libraries.
+//
+// Independent versioning (NOT std's lockstep): every publishable library ships
+// its OWN version, bumped independently by release-please from conventional
+// commits, and release-please writes the new number straight into each
+// package's own manifest before this script ever runs. Publishing here is
+// therefore just "walk the dependency graph leaf-first and ship whatever's
+// committed" -- no `--version` fan-out like std's script has.
+//
+// Package discovery + Kahn's-algorithm tiering are unchanged from std's shape:
+// PUBLISHABLE = has a `publishConfig` key and isn't `"private": true`, tiered
+// over `workspace:*` deps so a package never ships before a sibling it depends
+// on. Ordering matters here specifically because a dependent's packed tarball
+// embeds the dependency's CURRENT version (see the pnpm pack note below), so
+// publishing out of order would ship a tarball pinned to a version not yet live.
+//
+// STAGED, not direct, publish. Every @rhombus-toolkit package's npm Trusted
+// Publisher allows both `npm publish` and `npm stage publish`; this script
+// deliberately uses the latter. `npm stage publish` uploads the tarball
+// without going live -- the version sits pending until a human runs
+// `npm stage approve <id>`, which DOES require 2FA (OIDC trust tokens can
+// stage but cannot approve -- verified against npm's staged-publish docs).
+// That makes an 11-package release atomic in the way that matters: a
+// mid-sequence CI failure leaves everything staged so far merely PENDING, not
+// live, so there's no partial release to unwind -- reject the bad ones, fix,
+// rerun.
+//
+// `pnpm pack`, not `pnpm publish`: pnpm has no staged-publish mode as of pnpm
+// 10.34 (pnpm/pnpm#13183, open). `pnpm pack` alone already does the two things
+// that matter -- applies the publishConfig dist-swap and rewrites `workspace:*`
+// dependency ranges to the sibling's current concrete version (both verified
+// against this repo's manifests) -- neither of which plain `npm pack` does.
+// `npm stage publish <tarball>` then uploads exactly that tarball; npm never
+// re-derives publishConfig itself, so pnpm has to have done it already.
+//
+// Two modes:
+//   --list      print publishable names, topological order, one per line
+//   --publish   pnpm pack + npm stage publish each package, in order
+//
+// A failed pack/stage exits non-zero immediately.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+interface Manifest {
+  readonly name: string;
+  readonly private?: boolean;
+  readonly publishConfig?: Record<string, unknown>;
+  readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+  readonly peerDependencies?: Record<string, string>;
+}
+
+interface Package {
+  readonly name: string;
+  /** Absolute path to the package directory (cwd for pnpm/npm invocations). */
+  readonly dir: string;
+  /** Workspace-sibling package names this one depends on (any dependency kind). */
+  readonly deps: readonly string[];
+}
+
+const ROOT = `${import.meta.dir}/..`;
+const GROUP = 'libraries';
+
+/** Yields the workspace-protocol dependency names across every dependency kind. */
+function* workspaceDeps(manifest: Manifest): Generator<string> {
+  const fields = [manifest.dependencies, manifest.devDependencies, manifest.peerDependencies];
+  for (const field of fields) {
+    for (const [name, spec] of Object.entries(field ?? {})) {
+      if (String(spec).startsWith('workspace:')) {
+        yield name;
+      }
+    }
+  }
+}
+
+/** Reads every publishable library manifest (has `publishConfig`, not `private`) into a name -> Package map. */
+function discoverPackages(): Map<string, Package> {
+  const packages = new Map<string, Package>();
+  let entries: string[];
+  try {
+    entries = readdirSync(`${ROOT}/${GROUP}`);
+  } catch {
+    return packages;
+  }
+  for (const entry of entries) {
+    const dir = `${ROOT}/${GROUP}/${entry}`;
+    let manifest: Manifest;
+    try {
+      manifest = JSON.parse(readFileSync(`${dir}/package.json`, 'utf8')) as Manifest;
+    } catch {
+      continue;
+    }
+    // Publishable = has publishConfig and is not private. `typed-pluralizer`
+    // carries neither field on purpose -- see its manifest comment.
+    if (!manifest.publishConfig || manifest.private) {
+      continue;
+    }
+    packages.set(manifest.name, { name: manifest.name, dir, deps: [...new Set(workspaceDeps(manifest))] });
+  }
+  return packages;
+}
+
+/**
+ * Peels the graph into dependency tiers (Kahn's algorithm): tier 0 depends on
+ * nothing publishable, tier N depends only on tiers < N. Throws on a cycle.
+ * A package's dependencies on non-publishable siblings don't gate its ordering.
+ */
+function computeTiers(packages: Map<string, Package>): string[][] {
+  const pending = new Map<string, Set<string>>();
+  for (const pkg of packages.values()) {
+    pending.set(pkg.name, new Set(pkg.deps.filter((dep) => packages.has(dep))));
+  }
+
+  const tiers: string[][] = [];
+  while (pending.size) {
+    const tier = [...pending].filter(([, deps]) => !deps.size).map(([name]) => name);
+    if (!tier.length) {
+      throw new Error(`publish-libraries: dependency cycle among ${[...pending.keys()].join(', ')}`);
+    }
+    for (const name of tier) {
+      pending.delete(name);
+    }
+    for (const deps of pending.values()) {
+      for (const name of tier) {
+        deps.delete(name);
+      }
+    }
+    tiers.push(tier.sort());
+  }
+  return tiers;
+}
+
+const packages = discoverPackages();
+const tiers = computeTiers(packages);
+const ordered = tiers.flat().map((name) => packages.get(name)!);
+
+const mode = process.argv[2];
+
+if (mode === '--list') {
+  for (const pkg of ordered) {
+    console.log(pkg.name);
+  }
+  process.exit(0);
+}
+
+if (mode !== '--publish') {
+  console.error('usage: publish-libraries.ts --list | --publish');
+  process.exit(2);
+}
+
+interface PackResult {
+  readonly filename: string;
+}
+
+/** `pnpm pack`'s tarball path -- the publishConfig-rewritten package npm will stage. */
+function packTarball(pkg: Package, destDir: string): string {
+  const result = spawnSync('pnpm', ['pack', '--json', '--pack-destination', destDir], { cwd: pkg.dir });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+  return (JSON.parse(result.stdout.toString()) as PackResult).filename;
+}
+
+const destDir = mkdtempSync(`${tmpdir()}/rhombus-publish-`);
+
+for (const pkg of ordered) {
+  console.log(`\n▶ stage ${pkg.name}`);
+  const tarball = packTarball(pkg, destDir);
+  const stage = spawnSync('npm', ['stage', 'publish', tarball, '--provenance'], { cwd: pkg.dir, stdio: 'inherit' });
+  if (stage.status !== 0) {
+    process.exit(stage.status ?? 1);
+  }
+}


### PR DESCRIPTION
## Summary

P2 of the repo reorg: the publish pipeline, wired but inert until a human
flips it on.

- release-please configured for independent per-package versioning across
  the 11 publishable libraries (not std's lockstep) -- separate release PRs,
  driven by the conventional commits this repo already writes.
- `scripts/publish-libraries.ts`: topological (Kahn's algorithm) publish over
  `workspace:*` deps, `pnpm pack` (applies the publishConfig dist-swap +
  workspace:* -> concrete version rewrite) + `npm stage publish` (OIDC trusted
  publishing, staged rather than direct -- see the script header for why).
- `scripts/derive-publish-config.ts`: derives each package's `publishConfig`
  from its dev `exports` mechanically, `--check`/`--write` modes, wired into
  `bun run lint` so drift fails the build.
- `.github/workflows/release.yml`: release-please + build + stage-publish,
  gated behind the (not-yet-created) `PUBLISHING_ENABLED` repo variable. Must
  stay named exactly this -- all 17 packages' npm Trusted Publishers already
  point at this filename.

Two gates before anything reaches npm: our own `PUBLISHING_ENABLED` repo
variable, and npm's own staged-publish approval (`npm stage publish` from CI
needs no 2FA; going live needs a human to run `npm stage approve <id>`, which
does).

## External setup still required (cannot be scripted)

- `PUBLISHING_ENABLED` repo variable -- doesn't exist, so `publish` can't run.
- `AUTOMERGE_PAT` secret -- release-please's PRs need a PAT (not
  `GITHUB_TOKEN`) to trigger the `verify` check; without it the token-check
  step no-ops release-please cleanly rather than failing CI.

## Test plan

- [x] `bun install && bun run build && bun run typecheck && bun run lint && bun run format:check` all green
- [x] `bun scripts/publish-libraries.ts --list` prints the 11 publishable packages, deps before dependents
- [x] `bun scripts/derive-publish-config.ts --check` passes against every current manifest
- [x] verified by hand (`pnpm pack --json`) that publishConfig rewriting and workspace:* -> concrete-version resolution both work as the scripts assume
- [ ] cannot verify the live `npm stage publish` path or release-please's actual PR behavior without the external setup above