### PR TITLE
feat(platform): add package for typed host-platform globals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
       "version": "1.4.4",
       "dependencies": {
         "@rhombus-toolkit/func": "workspace:*",
-        "@rhombus-toolkit/set-immediate": "workspace:*",
+        "@rhombus-toolkit/platform": "workspace:*",
       },
     },
     "libraries/case-converter": {

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,13 @@
       "name": "@rhombus-toolkit/kinda-weak-map",
       "version": "1.4.2",
     },
+    "libraries/platform": {
+      "name": "@rhombus-toolkit/platform",
+      "version": "0.1.0",
+      "dependencies": {
+        "@rhombus-toolkit/func": "workspace:*",
+      },
+    },
     "libraries/proxy-base": {
       "name": "@rhombus-toolkit/proxy-base",
       "version": "1.0.0",
@@ -198,6 +205,8 @@
     "@rhombus-toolkit/func": ["@rhombus-toolkit/func@workspace:libraries/func"],
 
     "@rhombus-toolkit/kinda-weak-map": ["@rhombus-toolkit/kinda-weak-map@workspace:libraries/kinda-weak-map"],
+
+    "@rhombus-toolkit/platform": ["@rhombus-toolkit/platform@workspace:libraries/platform"],
 
     "@rhombus-toolkit/proxy-base": ["@rhombus-toolkit/proxy-base@workspace:libraries/proxy-base"],
 

--- a/libraries/async-timers/package.json
+++ b/libraries/async-timers/package.json
@@ -31,7 +31,7 @@
   "author": "Thomas Butler",
   "dependencies": {
     "@rhombus-toolkit/func": "workspace:*",
-    "@rhombus-toolkit/set-immediate": "workspace:*"
+    "@rhombus-toolkit/platform": "workspace:*"
   },
   "publishConfig": {
     "access": "public",

--- a/libraries/async-timers/src/setImmediateAsync.ts
+++ b/libraries/async-timers/src/setImmediateAsync.ts
@@ -1,4 +1,4 @@
-import { clearImmediate, setImmediate } from '@rhombus-toolkit/set-immediate';
+import { clearImmediate, setImmediate } from '@rhombus-toolkit/platform';
 
 export function setImmediateAsync(): Promise<void>;
 export function setImmediateAsync(signal: AbortSignal): Promise<void>;

--- a/libraries/async-timers/tsconfig.ci.json
+++ b/libraries/async-timers/tsconfig.ci.json
@@ -1,5 +1,5 @@
 {
-  "//": "lib: [\"ES2015\", \"DOM\"] is the floor this package actually needs. Promise lands in ES2015; verified ES5+DOM fails on it (TS2585). DOM supplies AbortSignal/EventTarget/AddEventListenerOptions/Event (listenEventAsync.ts) and the browser-flavored setTimeout/clearTimeout (setTimeoutAsync.ts) -- setImmediate/clearImmediate come from the workspace @rhombus-toolkit/set-immediate package, not an ambient global, so no Node types are needed here.",
+  "//": "lib: [\"ES2015\", \"DOM\"] is the floor this package actually needs. Promise lands in ES2015; verified ES5+DOM fails on it (TS2585). DOM supplies AbortSignal/EventTarget/AddEventListenerOptions/Event (listenEventAsync.ts) and the browser-flavored setTimeout/clearTimeout (setTimeoutAsync.ts) -- setImmediate/clearImmediate come from the workspace @rhombus-toolkit/platform package's typed globalThis lookup, not an ambient global, so no Node types are needed here.",
   "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
     "lib": ["ES2015", "DOM"]

--- a/libraries/platform/compat/ReadableStream.test.ts
+++ b/libraries/platform/compat/ReadableStream.test.ts
@@ -1,0 +1,13 @@
+// Assignability probe proving the owned ReadableStream<R> doesn't conflict
+// with the real lib.dom ReadableStream<R>. Compiled by ../tsconfig.compat.json
+// (lib: ["ES2022", "DOM"]), never by the package's own tsconfig.ci.json.
+
+import type { ReadableStream as OwnedReadableStream } from '../src/ReadableStream';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+
+namespace readableStreamAssignsToOwned {
+  // a real DOM ReadableStream<R> assigns to the owned structural type
+  // @ts-expect-no-error
+  isAssignable<ReadableStream<Uint8Array>, OwnedReadableStream<Uint8Array>>;
+}

--- a/libraries/platform/compat/TimeoutHandle.test.ts
+++ b/libraries/platform/compat/TimeoutHandle.test.ts
@@ -1,0 +1,26 @@
+// Assignability probes proving the owned opaque TimeoutHandle round-trips a
+// real platform handle regardless of shape -- a DOM browser handle (number)
+// and a Node-shaped handle (an object with ref/unref, structurally, since
+// @types/node itself is out of scope for this program). Compiled by
+// ../tsconfig.compat.json (lib: ["ES2022", "DOM"]), never by the package's
+// own tsconfig.ci.json.
+
+import type { TimeoutHandle } from '../src/TimeoutHandle';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+
+namespace browserHandleRoundTrips {
+  // the DOM setTimeout/clearTimeout handle shape (a number) crosses into the opaque owned type
+  // @ts-expect-no-error
+  isAssignable<number, TimeoutHandle>;
+}
+
+namespace nodeShapedHandleRoundTrips {
+  interface NodeTimeoutLike {
+    ref(): this;
+    unref(): this;
+  }
+  // Node's non-number Timeout handle also crosses into the opaque owned type
+  // @ts-expect-no-error
+  isAssignable<NodeTimeoutLike, TimeoutHandle>;
+}

--- a/libraries/platform/compat/Url.test.ts
+++ b/libraries/platform/compat/Url.test.ts
@@ -1,0 +1,16 @@
+// Assignability probes proving the owned Url doesn't conflict with the real
+// lib.dom URL. Compiled by ../tsconfig.compat.json (lib: ["ES2022", "DOM"]),
+// never by the package's own tsconfig.ci.json.
+
+import type { Url as OwnedUrl } from '../src/Url';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+
+namespace urlCrossesBothWays {
+  // a real DOM URL assigns to the owned structural type
+  // @ts-expect-no-error
+  isAssignable<URL, OwnedUrl>;
+  // the owned Url assigns back to DOM's
+  // @ts-expect-no-error
+  isAssignable<OwnedUrl, URL>;
+}

--- a/libraries/platform/compat/abort.test.ts
+++ b/libraries/platform/compat/abort.test.ts
@@ -1,0 +1,29 @@
+// Assignability probes proving the owned abort.ts types don't conflict with
+// the real lib.dom globals when both are present in a consumer's program.
+// Compiled by ../tsconfig.compat.json (lib: ["ES2022", "DOM"]), never by the
+// package's own tsconfig.ci.json.
+
+import { AbortController as OwnedAbortController, AbortSignal as OwnedAbortSignal, neverSignal } from '../src/abort';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+
+namespace abortSignalCrossesBothWays {
+  // a real DOM AbortSignal assigns to the owned structural type
+  // @ts-expect-no-error
+  isAssignable<AbortSignal, OwnedAbortSignal>;
+  // the owned AbortSignal assigns back to DOM's
+  // @ts-expect-no-error
+  isAssignable<OwnedAbortSignal, AbortSignal>;
+}
+
+namespace abortControllerAssignsToOwned {
+  // a real DOM AbortController assigns to the owned structural type
+  // @ts-expect-no-error
+  isAssignable<AbortController, OwnedAbortController>;
+}
+
+namespace neverSignalCrossesToReal {
+  // the concrete neverSignal singleton is usable wherever a real AbortSignal is expected
+  // @ts-expect-no-error
+  isAssignable<typeof neverSignal, AbortSignal>;
+}

--- a/libraries/platform/package.json
+++ b/libraries/platform/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@rhombus-toolkit/platform",
+  "version": "0.1.0",
+  "description": "Structural typings for host-platform globals (AbortController, process, ReadableStream, timers, URL), each a typed globalThis lookup rather than an ambient declaration.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rhombus-toolkit/ts.git",
+    "directory": "libraries/platform"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/bundle/index.js",
+  "types": "./dist/bundle/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "bun": "./dist/bundle/index.js",
+      "types": "./dist/bundle/index.d.ts",
+      "import": "./dist/bundle/index.js",
+      "default": "./dist/bundle/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bun ../../scripts/build-lib.ts",
+    "lint": "bun x tsc --noEmit -p tsconfig.ci.json && bun x tsc --noEmit -p tsconfig.compat.json"
+  },
+  "keywords": [],
+  "author": "Thomas Butler",
+  "dependencies": {
+    "@rhombus-toolkit/func": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "main": "./dist/bundle/index.js",
+    "types": "./dist/bundle/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/bundle/index.d.ts",
+        "import": "./dist/bundle/index.js",
+        "default": "./dist/bundle/index.js"
+      }
+    }
+  }
+}

--- a/libraries/platform/rollup.dts.mjs
+++ b/libraries/platform/rollup.dts.mjs
@@ -1,0 +1,14 @@
+// Rolls the public type surface of @rhombus-toolkit/platform into a single
+// dist/bundle/index.d.ts. `respectExternal: true` keeps the cross-package
+// @rhombus-toolkit/func import as a real import in the rolled output rather
+// than inlining it.
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dts } from 'rollup-plugin-dts';
+
+const PKG_ROOT = dirname(fileURLToPath(import.meta.url));
+
+export default { input: join(PKG_ROOT, 'src', 'index.ts'),
+  output: { file: join(PKG_ROOT, 'dist', 'bundle', 'index.d.ts'), format: 'es' },
+  plugins: [dts({ tsconfig: join(PKG_ROOT, 'tsconfig.json'), respectExternal: true })] };

--- a/libraries/platform/src/ImmediateHandle.ts
+++ b/libraries/platform/src/ImmediateHandle.ts
@@ -1,0 +1,40 @@
+// Owned `setImmediate`/`clearImmediate` typing (like ./abort.ts): typed
+// re-exports off `globalThis`, no polyfill import, no global mutation --
+// unlike the package this absorbs (`@rhombus-toolkit/set-immediate`), which
+// deleted `globalThis.setImmediate`/`clearImmediate` after capturing them, a
+// hostile side effect that made its own `sideEffects: false` a lie.
+//
+// One real divergence from every other global this package wraps:
+// `setImmediate` is deliberately Node/bun-only and does not exist in
+// browsers. That is why the absorbed package pulled the 2014-era
+// `setimmediate` npm polyfill. This package does not: `globalThis` here is
+// only ever a typed lookup, never a source of runtime behavior, so adding a
+// `MessageChannel`-based fallback would mean actually implementing scheduling
+// logic rather than typing an existing global -- out of scope for what this
+// package is. A browser consumer sees `setImmediate`/`clearImmediate` as
+// `undefined` at runtime; document that plainly rather than pretend the
+// global is universal.
+//
+// `ImmediateHandle` is opaque (`unknown`) for the same reason `TimeoutHandle`
+// is: Node's real return value is an `Immediate` object, not the `number` the
+// absorbed package's types claimed, and it only ever round-trips through our
+// own `clearImmediate`.
+
+import { Func } from '@rhombus-toolkit/func';
+
+export type ImmediateHandle = unknown;
+
+interface SetImmediateLike {
+  <Args extends readonly unknown[]>(callback: Func<Args, void>, ...args: Args): ImmediateHandle;
+}
+interface ClearImmediateLike {
+  (handle: ImmediateHandle): void;
+}
+
+/** The platform `setImmediate`, re-typed with an opaque handle. Node/bun-only -- `undefined` in browsers. */
+export const setImmediate: SetImmediateLike =
+  (globalThis as unknown as { setImmediate: SetImmediateLike; }).setImmediate;
+
+/** The platform `clearImmediate`, accepting {@link ImmediateHandle}. Node/bun-only -- `undefined` in browsers. */
+export const clearImmediate: ClearImmediateLike =
+  (globalThis as unknown as { clearImmediate: ClearImmediateLike; }).clearImmediate;

--- a/libraries/platform/src/ReadableStream.ts
+++ b/libraries/platform/src/ReadableStream.ts
@@ -1,0 +1,17 @@
+// Owned `ReadableStream<R>` typing (like ./abort.ts) for the one stream type
+// that reaches a public signature — fileproviders.core's
+// `IFileInfo.createReadStream(): ReadableStream<Uint8Array>`. Only the members
+// this repo relies on are precise; the plumbing whose shape diverges across
+// platform stream variants is left loose (`any`) so an implementer on any
+// variant stays assignable to it.
+
+export interface ReadableStream<R = any> {
+  readonly locked: boolean;
+  cancel(reason?: any): Promise<void>;
+  getReader: any; // loose: reader shape differs across lib.dom/@types/node variants
+  pipeThrough: any;
+  pipeTo: any;
+  tee: any;
+  /** Phantom use of R -- signature fidelity + variance; never present at runtime. */
+  readonly __chunkType?: R;
+}

--- a/libraries/platform/src/TimeoutHandle.ts
+++ b/libraries/platform/src/TimeoutHandle.ts
@@ -1,0 +1,23 @@
+// Owned timer typings (like ./abort.ts): typed `setTimeout`/`clearTimeout`
+// re-exports off `globalThis`, so libraries schedule timeouts without an ambient
+// platform type. `TimeoutHandle` is opaque (`unknown`) — the platform handle
+// type differs (a number in browsers, an object under node) and only ever
+// round-trips through our own `clearTimeout`.
+
+import { Func } from '@rhombus-toolkit/func';
+
+export type TimeoutHandle = unknown;
+
+interface SetTimeoutLike {
+  (callback: Func<[], void>, delayMs?: number): TimeoutHandle;
+}
+interface ClearTimeoutLike {
+  (handle: TimeoutHandle): void;
+}
+
+/** The platform `setTimeout`, re-typed with an opaque handle. */
+export const setTimeout: SetTimeoutLike = (globalThis as unknown as { setTimeout: SetTimeoutLike; }).setTimeout;
+
+/** The platform `clearTimeout`, accepting {@link TimeoutHandle}. */
+export const clearTimeout: ClearTimeoutLike =
+  (globalThis as unknown as { clearTimeout: ClearTimeoutLike; }).clearTimeout;

--- a/libraries/platform/src/Url.ts
+++ b/libraries/platform/src/Url.ts
@@ -1,0 +1,32 @@
+// Owned `URL`/`Url` typing (like ./abort.ts): a typed `globalThis` lookup so
+// `@rhombus-toolkit/type-guards`'s parked `isUrl` can name a `URL`-shaped
+// value without pulling all of lib.dom in for one identifier. `searchParams`
+// is left loose (`any`) -- `URLSearchParams`'s shape diverges across
+// lib.dom/@types/node/bun-types, and naming it would drag in the second lib
+// type this whole pattern exists to avoid.
+
+import { Ctor } from '@rhombus-toolkit/func';
+
+/** Structural counterpart of the platform `URL`. */
+export interface Url {
+  hash: string;
+  host: string;
+  hostname: string;
+  href: string;
+  readonly origin: string;
+  password: string;
+  pathname: string;
+  port: string;
+  protocol: string;
+  search: string;
+  username: string;
+  readonly searchParams: any; // loose: URLSearchParams diverges across variants
+  toString(): string;
+  toJSON(): string;
+}
+
+/** Constructor shape for {@link Url}, matching the platform global's static side. */
+export type UrlConstructor = Ctor<[url: string, base?: string], Url>;
+
+/** The platform `URL` constructor, re-typed against the owned structural interface. */
+export const URL: UrlConstructor = (globalThis as unknown as { URL: UrlConstructor; }).URL;

--- a/libraries/platform/src/abort.ts
+++ b/libraries/platform/src/abort.ts
@@ -1,0 +1,49 @@
+// Structural AbortSignal/AbortController typings, owned here so libraries can
+// name these globals without pulling lib.dom / @types/node / bun-types into
+// their published .d.ts. Typed for mutual assignability with both the lib.dom
+// and @types/node variants: the members this repo calls are precise; the
+// EventTarget plumbing it never touches (`onabort`, `dispatchEvent`) is left
+// loose (`any`) so a signal crosses the boundary either way (e.g. passing one
+// to `fetch(url, { signal })`). The value export below IS
+// `globalThis.AbortController` — native in Node >=15 / bun / deno / browsers.
+
+import { Ctor } from '@rhombus-toolkit/func';
+
+/** Structural counterpart of the platform `AbortSignal`. */
+export interface AbortSignal {
+  readonly aborted: boolean;
+  readonly reason: any;
+  onabort: any; // loose: plumbing we never touch
+  throwIfAborted(): void;
+  addEventListener(type: 'abort', listener: (this: AbortSignal, event: any) => void,
+    options?: boolean | { once?: boolean; }): void;
+  removeEventListener(type: 'abort', listener: (this: AbortSignal, event: any) => void): void;
+  dispatchEvent(event: any): boolean;
+}
+
+/** Structural counterpart of the platform `AbortController`. */
+export interface AbortController {
+  readonly signal: AbortSignal;
+  abort(reason?: any): void;
+}
+
+/**
+ * Constructor shape for {@link AbortController}, matching the platform
+ * global's static side.
+ */
+export type AbortControllerConstructor = Ctor<[], AbortController>;
+
+/** The platform `AbortController` constructor, re-typed against the owned structural interface. */
+export const AbortController: AbortControllerConstructor =
+  // The bare-library `globalThis` type lacks these properties, so the cast goes through `unknown`.
+  (globalThis as unknown as { AbortController: AbortControllerConstructor; }).AbortController;
+
+/**
+ * A singleton inert signal that never aborts. Pass it where an
+ * {@link AbortSignal} is required but cancellation is genuinely not-applicable;
+ * every member is a no-op.
+ */
+export const neverSignal: AbortSignal = { aborted: false, reason: undefined, onabort: null, throwIfAborted() {},
+  addEventListener() {}, removeEventListener() {}, dispatchEvent() {
+  return false;
+} };

--- a/libraries/platform/src/index.ts
+++ b/libraries/platform/src/index.ts
@@ -1,0 +1,11 @@
+// Structural typings for the host platform, each a typed `globalThis` lookup
+// rather than an ambient declaration. Reaching the platform through these is
+// what lets every library compile with `types: []` — no lib.dom, no
+// `@types/node`, no bun-types anywhere in the graph.
+
+export * from './abort';
+export * from './ImmediateHandle';
+export * from './process';
+export type * from './ReadableStream';
+export * from './TimeoutHandle';
+export * from './Url';

--- a/libraries/platform/src/process.ts
+++ b/libraries/platform/src/process.ts
@@ -1,0 +1,20 @@
+// Owned `process` typing (like ./abort.ts): a typed re-export off `globalThis`
+// so libraries can touch the process without an ambient platform type only
+// @types/node would supply. `ProcessLike` covers only the members this repo
+// calls — extend it when a consumer needs another.
+
+import { Func } from '@rhombus-toolkit/func';
+
+export interface ProcessLike {
+  readonly env: Record<string, string | undefined>;
+  cwd(): string;
+  readonly stdout: { write(chunk: string): boolean; };
+  on(event: string, listener: Func<[], void>): unknown;
+  off(event: string, listener: Func<[], void>): unknown;
+}
+
+/**
+ * The platform `process` global, re-typed against {@link ProcessLike}. No
+ * runtime fallback -- node/bun/deno all supply it.
+ */
+export const process: ProcessLike = (globalThis as unknown as { process: ProcessLike; }).process;

--- a/libraries/platform/tsconfig.ci.json
+++ b/libraries/platform/tsconfig.ci.json
@@ -1,0 +1,5 @@
+{
+  "//": "lib: [\"ES5\"] -- inherited from the base as-is; every type here is a locally-declared interface plus `Record` (lib.es5.d.ts), so nothing pulls in anything higher. ES5 is also TS's lowest `lib` entry -- there is no rung below it to verify a failure against. DOM stays absent: every platform global is reached by casting `globalThis` through an owned structural type, never by naming a DOM type, and types: [] (from tsconfig.lib.json) keeps @types/node and bun-types out too. See tsconfig.compat.json for the companion no-conflict-with-real-libs program.",
+  "extends": "../../tsconfig.lib.json",
+  "include": ["src/**/*"]
+}

--- a/libraries/platform/tsconfig.compat.json
+++ b/libraries/platform/tsconfig.compat.json
@@ -1,0 +1,8 @@
+{
+  "//": "The no-conflict-when-real-libs-ARE-present program: everything platform's own tsconfig.ci.json keeps out (DOM) is turned back on here, and compat/**/* probes that a real lib.dom AbortSignal/AbortController/ReadableStream/URL assigns to the owned structural type and, where claimed, back again. types: [] (inherited from tsconfig.lib.json) stays -- this is about lib.dom specifically, not about admitting @types/node/bun-types too. Not run for `process`/`ImmediateHandle`: `process` has no lib.dom counterpart at all (it's an @types/node-only global), and `setImmediate` is deliberately absent from lib.dom -- there is nothing to cross-check either belongs to this program.",
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["compat/**/*"]
+}

--- a/libraries/platform/tsconfig.json
+++ b/libraries/platform/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.editor.json",
+  "include": ["../*/src/**/*"]
+}


### PR DESCRIPTION
## Summary
- New `@rhombus-toolkit/platform`: structural typings for host-platform globals (`AbortController`/`AbortSignal`/`neverSignal`, `process`, `ReadableStream`, `TimeoutHandle`/`setTimeout`/`clearTimeout`), each a typed `globalThis` lookup instead of an ambient declaration -- consumers compile with `types: []`, no lib.dom/`@types/node`/bun-types leaking into published `.d.ts`.
- Ported verbatim from `std`'s `primitives/platform`, plus two new members: `ImmediateHandle`/`setImmediate`/`clearImmediate` (absorbing `@rhombus-toolkit/set-immediate`'s job without its global-deleting side effect or 2014-era polyfill) and `Url`/`URL` (unblocks `type-guards`' parked `isUrl`).
- `async-timers`' `setImmediateAsync` now sources `setImmediate`/`clearImmediate` from `platform`. `set-immediate` itself is untouched -- not deleted, per the reorg plan.
- Lib floor is `ES5` (the repo's absolute floor -- everything here is a locally-declared interface plus `Record`, nothing needs more, and there's no `lib` entry below `ES5` to fall back to).
- `setImmediate` is documented as Node/bun-only (`undefined` in browsers) rather than backed by a `MessageChannel` fallback -- consistent with the package's "typed lookup, not a polyfill" design; every other global it wraps is universal, this one genuinely isn't.
- Added `tsconfig.compat.json` (`lib: ["ES2022", "DOM"]`) with assignability probes proving the owned types don't conflict with the real lib.dom globals when both are present in a consumer's program -- `AbortSignal`/`AbortController`/`ReadableStream`/`Url` cross both ways, `TimeoutHandle` accepts both a DOM-shaped and a Node-shaped real handle. Wired into the package's `lint` script alongside the normal `tsconfig.ci.json` check.

## Test plan
- [x] `bun install`
- [x] `bun run build` (full repo, `platform` builds in its topological tier; bundle-load smoke passes)
- [x] `bun run typecheck`
- [x] `bun run lint` (runs both `tsconfig.ci.json` and `tsconfig.compat.json` for `platform`)
- [x] `bun run format:check`