### PR TITLE
fix(defer): source AbortSignal/AbortController from platform

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,8 +29,8 @@
     "libraries/defer": {
       "name": "@rhombus-toolkit/defer",
       "version": "1.4.2",
-      "devDependencies": {
-        "@types/node": "^24.0.0",
+      "dependencies": {
+        "@rhombus-toolkit/platform": "workspace:*",
       },
     },
     "libraries/fetch": {

--- a/libraries/defer/package.json
+++ b/libraries/defer/package.json
@@ -29,8 +29,8 @@
   },
   "keywords": [],
   "author": "Thomas Butler",
-  "devDependencies": {
-    "@types/node": "^24.0.0"
+  "dependencies": {
+    "@rhombus-toolkit/platform": "workspace:*"
   },
   "publishConfig": {
     "access": "public",

--- a/libraries/defer/src/FnPromise.ts
+++ b/libraries/defer/src/FnPromise.ts
@@ -1,3 +1,6 @@
+import { AbortController } from '@rhombus-toolkit/platform';
+import type { AbortSignal } from '@rhombus-toolkit/platform';
+
 import { defer } from './defer';
 
 enum State {

--- a/libraries/defer/tsconfig.ci.json
+++ b/libraries/defer/tsconfig.ci.json
@@ -1,9 +1,8 @@
 {
-  "//": "lib: [\"ES2015\"] is the floor this package actually needs -- Promise (defer.ts, FnPromise.ts) lands in ES2015; verified ES5 fails on it (TS2468/TS2705/TS2585). DOM is deliberately absent -- AbortController/AbortSignal (FnPromise.ts) is the one pair that would otherwise need it. STOPGAP: types: [\"node\"] (Node's ambient AbortController/AbortSignal) is a placeholder, not the destination -- these belong in `platform` as owned structural types (P4), same shape as std's platform package, not as an @types/node dependency. Swap to platform once it lands.",
+  "//": "lib: [\"ES2018\"] is the floor this package actually needs -- Promise.prototype.finally (FnPromise.ts's then/catch/finally passthrough) lands in ES2018; verified ES2017 fails on it (TS2550). This floor moved up from the previously-recorded ES2015 now that types: [\"node\"] is gone: @types/node's own lib references were silently widening the program past what lib: [\"ES2015\"] alone implied, masking the real Promise.finally requirement. DOM is deliberately absent -- AbortController/AbortSignal (FnPromise.ts) is the one pair that would otherwise need it; both are now reached as owned structural types from `@rhombus-toolkit/platform` (a typed globalThis lookup), not an ambient global. Deliberately broke the platform import and confirmed tsc fails (TS2307), ruling out an ambient fallback.",
   "extends": "../../tsconfig.lib.json",
   "compilerOptions": {
-    "lib": ["ES2015"],
-    "types": ["node"]
+    "lib": ["ES2018"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

- `defer` reached `AbortSignal`/`AbortController` through `types: ["node"]` -- a documented stopgap (see the earlier `docs(defer)` commit) pulling in all of Node's ambient globals for two identifiers.
- Swaps `FnPromise.ts`'s executor signature and constructor call to `@rhombus-toolkit/platform`'s owned structural types (`import type { AbortSignal }` for the type, `import { AbortController }` for the runtime constructor).
- Drops `types: ["node"]` from `tsconfig.ci.json` (falls back to the shared `types: []` base) and the `@types/node` devDependency; adds `@rhombus-toolkit/platform` as a real `dependencies` entry (the `AbortController` binding is a runtime value, not just types).
- Re-verified the lib floor: removing `@types/node` exposed that its lib references had been silently widening the program -- `lib: ["ES2015"]` alone doesn't actually cover `Promise.prototype.finally` (`FnPromise`'s `then`/`catch`/`finally` passthrough). Real floor is `ES2018`; verified `ES2017` fails on it (TS2550). Comment updated with the finding.

## Test plan

- [x] `bun install`
- [x] `bun run build` (topological, defer's bundle-load smoke passes)
- [x] `bun run typecheck` (`tsc -b`, clean)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] Deliberately broke the platform import (`@rhombus-toolkit/platform-BROKEN`) and confirmed `tsc` fails with TS2307 -- rules out an ambient fallback resolving `AbortSignal`/`AbortController` from elsewhere
- [x] Compiled at `ES2017` (one rung below the new floor) and confirmed it fails with the recorded `Promise.finally` error (TS2550)