### PR TITLE
feat(proxy-base): add Indexed, the index-accessible view of an IndexAccessed subclass

### DIFF
--- a/libraries/proxy-base/src/IndexAccessed.ts
+++ b/libraries/proxy-base/src/IndexAccessed.ts
@@ -143,13 +143,13 @@ function createHandler(self: object, proto: object): ProxyHandler<object> {
  *     }
  * }
  *
- * const env = new Env();
- * const indexable = env as unknown as Record<string, string>;
- * indexable['HOME'] = '/home/tom';
- * indexable['HOME']; // '/home/tom'
- * env instanceof Env; // true
+ * const env = new Env() as Indexed<Env, string>;
+ * env['HOME'] = '/home/tom';
+ * env['HOME']; // '/home/tom'
+ * env instanceof Env; // true — `Indexed` keeps `Env`'s real members
  * ```
  *
+ * @see {@link Indexed} — the type that surfaces the index surface at the value site.
  * @see {@link ProxyBase} — the full-hook-surface sibling.
  *
  * @abstract
@@ -204,5 +204,48 @@ export abstract class IndexAccessed<Value, Key extends PropertyKey = PropertyKey
    */
   protected abstract _setIndex(key: Key, value: Value): Value;
 }
+
+/**
+ * The index-accessible view of an {@link IndexAccessed} subclass instance: the
+ * instance's real members intersected with the `Key`→`Value` index surface the
+ * proxy serves at runtime.
+ *
+ * @remarks
+ * The class itself cannot carry this index surface. TypeScript requires every
+ * named member of a type to be assignable to that type's index signature, and
+ * the {@link IndexAccessed._getIndex} / {@link IndexAccessed._setIndex} hooks —
+ * being methods, not `Value`s — never are. Declaring `[key: Key]: Value` on the
+ * class (or on anything it inherits, which would push the same error onto every
+ * subclass's hooks) is therefore a compile error. The indexer is a runtime-only
+ * construct, so its type is applied at the value site instead, via a cast:
+ *
+ * ```ts
+ * class Env extends IndexAccessed<string, 'HOME' | 'PATH'> {
+ *     protected _getIndex(key: 'HOME' | 'PATH'): string { throw new Error(key); }
+ *     protected _setIndex(_key: 'HOME' | 'PATH', value: string): string { return value; }
+ * }
+ *
+ * const env = new Env() as Indexed<Env, string, 'HOME' | 'PATH'>;
+ * env['HOME'];            // string
+ * env['PATH'] = '/bin';   // ok
+ * ```
+ *
+ * Unlike an `as unknown as Record<Key, Value>` cast — which throws the instance's
+ * real members away — `Indexed` intersects rather than replaces, so `env` above
+ * is still an `Env`: its declared methods and `instanceof` keep type-checking.
+ * Narrow `Key` (as here) to keep index access typed and to exclude real member
+ * names per the class-level "Narrowing `Key`" guidance; with the default
+ * `Key = PropertyKey`, `Indexed` yields the broad `string | number | symbol`
+ * index surface.
+ *
+ * @typeParam T - The subclass instance type being viewed.
+ * @typeParam Value - The value type the indexer reads and writes; matches the
+ * `Value` the subclass passed to {@link IndexAccessed}.
+ * @typeParam Key - The key type the index surface accepts; matches the `Key` the
+ * subclass passed to {@link IndexAccessed}. Defaults to `PropertyKey`.
+ */
+export type Indexed<T extends IndexAccessed<Value, Key>, Value, Key extends PropertyKey = PropertyKey> = T & {
+  [P in Key]: Value;
+};
 
 export default IndexAccessed;

--- a/libraries/proxy-base/src/index.ts
+++ b/libraries/proxy-base/src/index.ts
@@ -7,5 +7,5 @@
  * @packageDocumentation
  */
 
-export { IndexAccessed } from './IndexAccessed';
+export { IndexAccessed, type Indexed } from './IndexAccessed';
 export { default, ProxyBase } from './ProxyBase';


### PR DESCRIPTION
Rescued from the main checkout's working tree, where it was sitting uncommitted. It exists nowhere else — not on `main`, not in any of the reorg branches — so reverting that tree would have destroyed it.

`Indexed<T, Value, Key>` is the index-accessible view of an `IndexAccessed` subclass instance: the instance's real members intersected with the `Key`→`Value` index surface the proxy serves at runtime.

The class cannot carry the index surface itself. TypeScript requires every named member of a type to be assignable to that type's index signature, and the `_getIndex` / `_setIndex` hooks — being methods, not `Value`s — never are. Declaring `[key: Key]: Value` on the class, or on anything it inherits, is a compile error that would land on every subclass's hooks.

So the indexer's type is applied at the value site instead:

```ts
const env = new Env() as Indexed<Env, string, 'HOME' | 'PATH'>;
env['HOME'];            // string
env['PATH'] = '/bin';   // ok
env instanceof Env;     // still true
```

Unlike `as unknown as Record<Key, Value>` — which throws the instance's real members away — `Indexed` **intersects rather than replaces**, so the value stays an instance of its class with its declared methods and `instanceof` intact.

Rebased onto post-#275 `main` (the `index.ts` barrel conflicted with the toolchain reformat; resolved keeping both the new export and the formatting). Typecheck and format:check green.

Note `tests/src/proxy-base.ts` still exercises the older `as unknown as Record<PropertyKey, string>` cast pattern that this supersedes — worth switching in a follow-up.