### PR TITLE
chore(repo): pin first-release versions via release-as

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,12 +17,14 @@
     "libraries/kinda-weak-map": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/kinda-weak-map",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "2.0.0"
     },
     "libraries/obj": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/obj",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "1.0.0"
     },
     "libraries/platform": {
       "release-type": "node",
@@ -32,12 +34,14 @@
     "libraries/restify": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/restify",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "1.0.0"
     },
     "libraries/types": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/types",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "1.0.0"
     },
     "libraries/proxy-base": {
       "release-type": "node",
@@ -52,7 +56,8 @@
     "libraries/once": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/once",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "1.0.0"
     },
     "libraries/type-guards": {
       "release-type": "node",
@@ -61,16 +66,56 @@
     }
   },
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation", "hidden": true },
-    { "type": "refactor", "section": "Refactoring", "hidden": true },
-    { "type": "build", "section": "Build", "hidden": true },
-    { "type": "ci", "section": "CI", "hidden": true },
-    { "type": "chore", "section": "Chores", "hidden": true },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "style", "section": "Style", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "CI",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Chores",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Style",
+      "hidden": true
+    }
   ]
 }


### PR DESCRIPTION
types/obj/restify/once ship 1.0.0 as their first real release (std pins
^1.0.0-0; the computed 2.0.0 would not satisfy it). kinda-weak-map ships
2.0.0: values() changed to MapIterator<V | undefined>, a breaking change
the fix commit under-declared. Remove these pins after the release lands.
