### PR TITLE
chore(eslint): drop strict-boolean-expressions, apply autofixes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,8 +8,6 @@ export default tseslint.config({
   files: ['libraries/*/src/**/*.ts', 'tests/src/**/*.ts'],
   extends: [tseslint.configs.base],
   languageOptions: { parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname } },
-  rules: { curly: ['error', 'all'],
-    '@typescript-eslint/strict-boolean-expressions': ['error', { allowNullableBoolean: true, allowNullableString: true,
-      allowNullableNumber: true }], '@typescript-eslint/switch-exhaustiveness-check': 'error',
+  rules: { curly: ['error', 'all'], '@typescript-eslint/switch-exhaustiveness-check': 'error',
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }] },
 });

--- a/libraries/fetch/src/index.ts
+++ b/libraries/fetch/src/index.ts
@@ -55,7 +55,7 @@ export function wrapResponse(response: Response) {
     }
     // void async function pushit() {
     try {
-      while (true) { // eslint-disable-line no-constant-condition
+      while (true) {
         const { done, value } = await reader.read();
         if (done) {
           controller.close();

--- a/libraries/obj/src/flattenMap.ts
+++ b/libraries/obj/src/flattenMap.ts
@@ -85,7 +85,7 @@ export function flattenMap<T extends DeepDictionary<Leaf>, Leaf>(map: T,
   leafPredicate: (p: any) => p is Leaf): flattenMap<T, Leaf>;
 
 export function flattenMap(map: DeepDictionary<any>, leafPredicate: (p: any) => boolean = isFunction): any {
-  const result: Entry<string, any>[] = [];
+  const result: Array<Entry<string, any>> = [];
   const stack = Object.entries(map);
   while (stack.length) {
     const [prefix, branchOrLeaf] = stack.pop()!;

--- a/libraries/obj/src/iterable.test-d.ts
+++ b/libraries/obj/src/iterable.test-d.ts
@@ -9,7 +9,7 @@ declare function isAssignable<TExpected>(actual?: TExpected): void;
 // `T | undefined`.
 
 namespace isAllThereNarrowsAnArrayTest {
-  const items: (string | undefined)[] = [];
+  const items: Array<string | undefined> = [];
 
   // @ts-expect-error
   isAssignable<typeof items[0], string>;

--- a/libraries/obj/src/iterable.ts
+++ b/libraries/obj/src/iterable.ts
@@ -32,7 +32,7 @@ export function first<T>(source: Iterable<T>): T | undefined {
  * narrowed value it hands back yields nothing. Pass an array, a `Set`, or anything else that can
  * be iterated twice.
  */
-export function isAllThere<T>(items: readonly (T | undefined)[]): items is readonly T[];
+export function isAllThere<T>(items: ReadonlyArray<T | undefined>): items is readonly T[];
 export function isAllThere<T>(items: Iterable<T | undefined>): items is Iterable<T>;
 export function isAllThere(items: Iterable<unknown>): boolean {
   return Iterator.from(items).every(item => item !== undefined);
@@ -47,7 +47,7 @@ export function isAllThere(items: Iterable<unknown>): boolean {
  * carries `Symbol.iterator`. The `Iterator.from` on the iterable arm is what makes that hold rather
  * than throw — `flatMap` rejects a primitive outright, where `Iterator.from` iterates a string.
  */
-export function concat<T>(...args: readonly (Iterable<T> | T)[]): IteratorObject<T, undefined, unknown> {
+export function concat<T>(...args: ReadonlyArray<Iterable<T> | T>): IteratorObject<T, undefined, unknown> {
   return Iterator.from(args).flatMap(item => isIterable(item) ? Iterator.from(item as Iterable<T>) : [item]);
 }
 
@@ -114,7 +114,7 @@ export function zip<T1, T2, T3, T4, T5, T6, T7, T8, T9>(mode: 'outer', source1: 
   [T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined, T5 | undefined, T6 | undefined, T7 | undefined,
     T8 | undefined, T9 | undefined]
 >;
-export function* zip(mode: 'inner' | 'outer', ...sources: readonly Iterable<unknown>[]): Generator<unknown[]> {
+export function* zip(mode: 'inner' | 'outer', ...sources: ReadonlyArray<Iterable<unknown>>): Generator<unknown[]> {
   const iterators = sources.map(source => Iterator.from(source));
   while (true) {
     const results = iterators.map(iterator => iterator.next());

--- a/libraries/obj/src/obj.ts
+++ b/libraries/obj/src/obj.ts
@@ -43,14 +43,16 @@ type keyTuple<T extends {}> = UnionToTuple<StringKey<T>>;
  * a type parameter — a position where neither the tuple nor the test in front of it can be
  * evaluated, and an unevaluated conditional carries no members at all.
  */
-export type keys<T extends {}> = ([Untuplable<T>] extends [never] ? keyTuple<T> : unknown) & readonly StringKey<T>[];
+export type keys<T extends {}> = ([Untuplable<T>] extends [never] ? keyTuple<T> : unknown) & ReadonlyArray<
+  StringKey<T>
+>;
 export function keys<T extends {}>(obj: T): keys<T> {
   return Object.keys(obj) as any;
 }
 
 /** The members `Object.values` yields, symbol-named ones excluded as the runtime excludes them. */
 export type values<T extends {}> = T[StringKey<T>];
-export function values<T extends {}>(obj: T): values<T>[] {
+export function values<T extends {}>(obj: T): Array<values<T>> {
   return Object.values(obj) as any;
 }
 
@@ -65,7 +67,7 @@ export type AnyEntry<T extends {}> = { [K in StringKey<T>]: Entry<K, T[K]>; }[St
  * same reason.
  */
 export type entries<T extends {}> = ([Untuplable<T>] extends [never] ? keysToEntries<T, keyTuple<T>> : unknown)
-  & readonly AnyEntry<T>[];
+  & ReadonlyArray<AnyEntry<T>>;
 export function entries<T extends {}>(obj: T): entries<T> {
   return Object.entries(obj) as any;
 }
@@ -78,7 +80,7 @@ export function entries<T extends {}>(obj: T): entries<T> {
  * as a tuple and hands back a tuple; mapping straight over an unevaluated conditional maps something
  * that contributes `length` and the array methods as members of its own.
  */
-export type keysToEntries<T extends {}, Keys extends readonly StringKey<T>[]> = {
+export type keysToEntries<T extends {}, Keys extends ReadonlyArray<StringKey<T>>> = {
   [K in keyof Keys]: Entry<Keys[K], T[Keys[K]]>;
 };
 


### PR DESCRIPTION
Turns off `@typescript-eslint/strict-boolean-expressions` and applies every remaining autofixable lint issue.

## Changes

- **`chore(eslint)`** — removes the `strict-boolean-expressions` rule entry from `eslint.config.mjs`. Deleted rather than set to `'off'`, since `tseslint.configs.base` does not enable it and the `rules` block is an opt-in list.
- **`style(lint)`** — 9 `@typescript-eslint/array-type` fixes across `obj` and one stale `eslint-disable-line no-constant-condition` in `fetch`.

All `array-type` rewrites are type-identical (`readonly X[]` → `ReadonlyArray<X>`, `X[]` → `Array<X>`); no API or behavior change.

## Verification

- `eslint .` clean
- `tsc -b` clean
- `dprint check` clean