### PR TITLE
fix(obj): correlate mapValues' callback pair, add mapEntries

### DIFF
--- a/libraries/obj/src/map-entries.test-d.ts
+++ b/libraries/obj/src/map-entries.test-d.ts
@@ -1,0 +1,35 @@
+import { mapEntries, mapValues } from './obj';
+
+declare function isAssignable<TActual extends TExpected, TExpected>(actual?: TActual, expected?: TExpected): void;
+
+const source = { a: 1, b: 'x', c: true };
+
+// The pair arrives as one discriminated union, so testing the key narrows the value --
+// the correlation two separate `(key, value)` parameters would have lost.
+namespace correlatedEntryTest {
+  mapEntries(source, entry => {
+    if (entry[0] === 'a') {
+      // @ts-expect-no-error
+      isAssignable<typeof entry[1], number>();
+    }
+    if (entry[0] === 'b') {
+      // @ts-expect-no-error
+      isAssignable<typeof entry[1], string>();
+    }
+    return [entry[0], entry[1]] as const;
+  });
+}
+
+namespace mapEntriesResultTest {
+  const remapped = mapEntries(source, entry => [`k_${entry[0]}`, 0] as const);
+
+  // @ts-expect-no-error
+  isAssignable<typeof remapped, { k_a: 0; k_b: 0; k_c: 0; }>();
+}
+
+namespace mapValuesResultTest {
+  const lengths = mapValues(source, entry => String(entry[1]).length);
+
+  // @ts-expect-no-error
+  isAssignable<typeof lengths, { a: number; b: number; c: number; }>();
+}

--- a/libraries/obj/src/obj.ts
+++ b/libraries/obj/src/obj.ts
@@ -3,9 +3,9 @@
 // call to it — import `obj` and call `obj.keys(x)` where the stock `Object.keys`
 // typing is too loose. Nothing here augments the global `ObjectConstructor`.
 
-import type { Flatten, Store, UnionToTuple } from '@rhombus-toolkit/types';
+import type { Flatten, Func, Store, UnionToTuple } from '@rhombus-toolkit/types';
 
-export type Entry<Key extends PropertyKey = PropertyKey, Value = any> = readonly [Key, Value];
+export type Entry<Key extends string = string, Value = any> = readonly [Key, Value];
 
 /** The keys `Object.keys` lists — string-named, so a symbol-named member never appears. */
 type StringKey<T> = Extract<keyof T, string>;
@@ -43,7 +43,7 @@ type keyTuple<T extends {}> = UnionToTuple<StringKey<T>>;
  * a type parameter — a position where neither the tuple nor the test in front of it can be
  * evaluated, and an unevaluated conditional carries no members at all.
  */
-export type keys<T extends {}> = ([Untuplable<T>] extends [never] ? keyTuple<T> : unknown) & ReadonlyArray<
+export type keys<T extends {}> = string & ([Untuplable<T>] extends [never] ? keyTuple<T> : unknown) & ReadonlyArray<
   StringKey<T>
 >;
 export function keys<T extends {}>(obj: T): keys<T> {
@@ -178,3 +178,24 @@ type Covers<T extends readonly any[], I extends readonly any[]> = number extends
 //     Reflect.setPrototypeOf(current, Reflect.getPrototypeOf(stuff));
 //     return Object.assign(target, stuff);
 //   }
+/**
+ * Remaps every pair of `obj` through `fn`, keyed by whatever key each result carries.
+ *
+ * @remarks
+ * `fn` takes the pair as ONE {@link AnyEntry} argument rather than as `(key, value)`, which is what
+ * keeps its halves correlated: testing `entry[0]` narrows `entry[1]` to that key's own member type.
+ * Spread across two parameters the checker widens them independently, and the callback body sees
+ * every key beside every value with no way to tell which pairing it was handed.
+ */
+export function mapEntries<Obj extends Record<string, any>, NewEntry extends Entry>(obj: Obj,
+  fn: Func<[entry: AnyEntry<Obj>], NewEntry>): fromEntries<NewEntry>
+{
+  return fromEntries(entries(obj).map(fn));
+}
+
+/** Every member of `obj` replaced by what `fn` returns for its pair, the keys left as they are. */
+export function mapValues<Obj extends Record<string, any>, NewValue>(obj: Obj,
+  fn: Func<[entry: AnyEntry<Obj>], NewValue>): { [K in StringKey<Obj>]: NewValue; }
+{
+  return Object.fromEntries(entries(obj).map(entry => [entry[0], fn(entry)])) as { [K in StringKey<Obj>]: NewValue; };
+}


### PR DESCRIPTION
`mapValues` could not type-check any call. Three faults:

1. `Func<entries<Obj>, NewValues>` used the *list* of pairs as the callback's parameter list, declaring a function of N entry-shaped parameters — but it was called as `fn(key, value)`.
2. `Record<keys<Obj>, NewValues>` keyed the result by `keys<Obj>`, a tuple type rather than a key union, and derived values from the wrong side.
3. Two separate `(key, value)` parameters can never stay correlated — destructuring widens them independently, so the body saw every key beside every value. That was the reported TS2345.

Passing the pair as one `AnyEntry<Obj>` argument keeps it a discriminated union, so testing the key narrows the value:

```ts
mapEntries({ a: 1, b: 'x' }, entry => {
  if (entry[0] === 'a') { entry[1]; }  // number
  if (entry[0] === 'b') { entry[1]; }  // string
  return [entry[0], entry[1]] as const;
});
```

Splits the two behaviors the original conflated: `mapEntries` remaps whole pairs (what the old body did), `mapValues` replaces members and keeps keys (what the old name promised). Drops the unused `EntryToFunc` alias.

## Verification

- `tsc -b` clean; the narrowing assertions are build-gating — unnarrowed, `entry[1]` would be `number | string | boolean` and fail.
- `eslint .` clean, `dprint` clean.
- Runtime checked: `{"k_a":1,"k_b":"x","k_c":true}` and `{"a":1,"b":1,"c":4}`.