### PR TITLE
chore(repo): repair the release bookkeeping so the new packages can ship

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-  "libraries/async-timers": "2.0.0",
-  "libraries/collections": "0.0.0-placeholder.0",
+  "libraries/async-timers": "2.0.1",
+  "libraries/collections": "1.0.0",
   "libraries/fetch": "2.0.0",
-  "libraries/iterable": "0.0.0-placeholder.0",
-  "libraries/obj": "1.0.0",
+  "libraries/iterable": "1.0.0",
+  "libraries/obj": "2.0.0",
   "libraries/platform": "1.1.0",
-  "libraries/proxy-base": "1.1.0",
-  "libraries/restify": "1.0.0",
-  "libraries/set-immediate": "1.3.3",
-  "libraries/once": "1.0.0",
-  "libraries/type-guards": "2.0.0",
-  "libraries/types": "1.0.0"
+  "libraries/proxy-base": "1.1.1",
+  "libraries/restify": "1.0.1",
+  "libraries/set-immediate": "1.3.4",
+  "libraries/once": "1.0.1",
+  "libraries/type-guards": "3.1.0",
+  "libraries/types": "1.0.1"
 }

--- a/libraries/collections/package.json
+++ b/libraries/collections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rhombus-toolkit/collections",
-  "version": "0.0.0-placeholder.0",
+  "version": "1.0.0",
   "description": "Collection data structures: ImmutableLinkedList (persistent, both ends known), KindaWeakMap (strong keys, weak values).",
   "repository": {
     "type": "git",

--- a/libraries/iterable/package.json
+++ b/libraries/iterable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rhombus-toolkit/iterable",
-  "version": "0.0.0-placeholder.0",
+  "version": "1.0.0",
   "description": "Iterable helpers: concat, first, firstDefined, iterable, replace, sequenceEquals, zip.",
   "repository": {
     "type": "git",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,8 +27,7 @@
     "libraries/obj": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/obj",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0"
+      "changelog-path": "CHANGELOG.md"
     },
     "libraries/platform": {
       "release-type": "node",
@@ -38,14 +37,12 @@
     "libraries/restify": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/restify",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0"
+      "changelog-path": "CHANGELOG.md"
     },
     "libraries/types": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/types",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0"
+      "changelog-path": "CHANGELOG.md"
     },
     "libraries/proxy-base": {
       "release-type": "node",
@@ -60,8 +57,7 @@
     "libraries/once": {
       "release-type": "node",
       "package-name": "@rhombus-toolkit/once",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0"
+      "changelog-path": "CHANGELOG.md"
     },
     "libraries/type-guards": {
       "release-type": "node",


### PR DESCRIPTION
Three things had to be true before `collections` and `iterable` could publish a real version, and none of them were.

## The manifest had drifted from npm

`.release-please-manifest.json` was behind what is actually published for eight of twelve packages:

| package | manifest said | actually live |
| --- | --- | --- |
| async-timers | 2.0.0 | 2.0.1 |
| obj | 1.0.0 | 2.0.0 |
| proxy-base | 1.1.0 | 1.1.1 |
| restify | 1.0.0 | 1.0.1 |
| set-immediate | 1.3.3 | 1.3.4 |
| once | 1.0.0 | 1.0.1 |
| type-guards | 2.0.0 | 3.1.0 |
| types | 1.0.0 | 1.0.1 |

`release.yml` publishes on each `package.json` version against npm, deliberately independent of release-please. release-please only learns a version shipped when its own release PR merges — and those were not merging, so it kept proposing releases that were already live. Nine were open at once. Manifest now records reality.

## The `release-as` pins were one-shot values left behind

`obj`, `restify`, `types` and `once` each carried `"release-as": "1.0.0"` — used to land a clean 1.0.0 during the reorg and never removed. A pin forces *every* subsequent release to that exact version, so `obj` could not move past 1.0.0 at all: the breaking `feat(obj)!` from the iterable split would have released as 1.0.0 again. All four dropped.

## The placeholder version was not inert

`collections` and `iterable` shipped as `0.0.0-placeholder.0` to reserve the names. The publish step skips any version already live, so neither could ever publish while wearing the placeholder — and release-please read it as a prerelease and proposed `1.0.0-placeholder.0`, staying on the prerelease track rather than leaving it. Both now carry a real `1.0.0`.

## After this merges

The publish job ships `@rhombus-toolkit/collections@1.0.0` and `@rhombus-toolkit/iterable@1.0.0`. **That requires an npm Trusted Publisher on `release.yml` for both new package names** — without it the publish fails and, because `publish-libraries.ts` exits non-zero on any non-duplicate failure, strands whatever is after them in the topological order. Every other package is already live at its manifest version, so the blast radius is just these two; re-running the workflow after configuring the publisher is the fix, since publishing is idempotent.

The nine stale release PRs should be closed and left to regenerate from the corrected manifest. #312 in particular releases `kinda-weak-map`, which no longer exists on `main`.

## Gates

`bun install`, `bun run build`, `bun run typecheck`, `bun run lint` (incl. `derive-publish-config --check`), `bun --filter '*' test`, `bun run format:check` — all green.