### PR TITLE
fix(repo): repair the three release-machinery failures from today

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "build": "bun scripts/build-all.ts",
-    "test": "bun --filter '*' test",
-    "lint": "bun --filter '*' lint && bun scripts/derive-publish-config.ts --check",
+    "test": "bun test scripts/ && bun --filter '*' test",
+    "lint": "bun --filter '*' lint && bun scripts/derive-publish-config.ts --check && bun scripts/check-release-please.ts --check",
     "format": "dprint fmt",
     "format:check": "dprint check",
     "knip": "knip --tsConfig tsconfig.knip.json --no-exit-code",

--- a/scripts/check-release-please.ts
+++ b/scripts/check-release-please.ts
@@ -1,0 +1,142 @@
+// Asserts that release-please's own bookkeeping still describes this workspace.
+//
+// Publishing is keyed on each `package.json` version against npm and is
+// DELIBERATELY independent of release-please (see publish-libraries.ts). That
+// independence is what keeps a release shippable when a release PR is stuck --
+// and it is also what lets the two silently separate: with release PRs left
+// unmerged, packages go live while `.release-please-manifest.json` still records
+// the version before them, and release-please keeps proposing releases that are
+// already published. Eight of twelve packages had drifted that way, one by a
+// full major, before this check existed.
+//
+// Three assertions, all offline -- npm is never consulted, so this runs in
+// `lint` alongside derive-publish-config.ts rather than in the release job:
+//
+//   1. PARITY   -- `.release-please-manifest.json["libraries/<name>"]` equals
+//                  that package's `package.json` version. A release PR writes
+//                  both in the same commit, so a mismatch means a version moved
+//                  outside release-please. That is the drift itself.
+//   2. COVERAGE -- every publishable library has a release-please-config.json
+//                  entry AND a manifest entry, and neither file names a package
+//                  that is no longer a publishable library.
+//   3. NO PINS  -- no `release-as` anywhere in the config. A pin there is
+//                  PERMANENT, not one-shot: release-please re-proposes that exact
+//                  version on every subsequent release. Four packages carried one
+//                  left over from the reorg, and it froze obj at 1.0.0 -- a
+//                  breaking change would have re-released the same version.
+//
+// One mode, mirroring derive-publish-config.ts:
+//   --check   exit non-zero listing every problem found.
+
+import { readdirSync, readFileSync } from 'node:fs';
+
+const ROOT = `${import.meta.dir}/..`;
+const LIBS = `${ROOT}/libraries`;
+const CONFIG_FILE = `${ROOT}/release-please-config.json`;
+const MANIFEST_FILE = `${ROOT}/.release-please-manifest.json`;
+
+interface Manifest {
+  readonly version: string;
+  readonly private?: boolean;
+  readonly publishConfig?: Record<string, unknown>;
+}
+
+interface ReleasePleaseEntry {
+  readonly 'release-as'?: string;
+}
+
+interface ReleasePleaseConfig {
+  readonly 'release-as'?: string;
+  readonly packages?: Record<string, ReleasePleaseEntry>;
+}
+
+interface Lib {
+  /** Repo-relative directory -- the key both release-please files are indexed by. */
+  readonly path: string;
+  readonly version: string;
+}
+
+/** Every publishable library (has a `publishConfig`, not marked private), keyed by its repo-relative path. */
+function discoverLibs(): Lib[] {
+  const libs: Lib[] = [];
+  for (const dir of readdirSync(LIBS)) {
+    let raw: string;
+    try {
+      raw = readFileSync(`${LIBS}/${dir}/package.json`, 'utf8');
+    } catch {
+      continue;
+    }
+    const manifest = JSON.parse(raw) as Manifest;
+    if (manifest.private || manifest.publishConfig === undefined) {
+      continue;
+    }
+    libs.push({ path: `libraries/${dir}`, version: manifest.version });
+  }
+  return libs.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/** Every way the two release-please files disagree with the workspace, one sentence each. */
+function* findProblems(): Generator<string> {
+  const config = JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) as ReleasePleaseConfig;
+  const released = JSON.parse(readFileSync(MANIFEST_FILE, 'utf8')) as Record<string, string>;
+  const configured = config.packages ?? {};
+  const libs = discoverLibs();
+  const paths = new Set(libs.map((lib) => lib.path));
+
+  for (const lib of libs) {
+    const recorded = released[lib.path];
+    if (!(lib.path in configured)) {
+      yield `${lib.path}: publishable, but release-please-config.json has no entry -- `
+        + `release-please will never propose a release for it.`;
+    }
+    if (recorded === undefined) {
+      yield `${lib.path}: publishable, but .release-please-manifest.json has no entry -- `
+        + `release-please has no released version to bump from.`;
+    } else if (recorded !== lib.version) {
+      yield `${lib.path}: package.json says ${lib.version}, .release-please-manifest.json says ${recorded}. `
+        + `A release PR writes both together, so they only diverge when a version moved outside release-please.`;
+    }
+  }
+
+  for (const path of Object.keys(configured)) {
+    if (!paths.has(path)) {
+      yield `${path}: release-please-config.json has an entry for something that is not a publishable library.`;
+    }
+  }
+  for (const path of Object.keys(released)) {
+    if (!paths.has(path)) {
+      yield `${path}: .release-please-manifest.json has an entry for something that is not a publishable library.`;
+    }
+  }
+
+  const pinned = [...(config['release-as'] === undefined ? [] : [['(config root)', config['release-as']] as const]),
+    ...Object.entries(configured).filter(([, entry]) => entry['release-as'] !== undefined).map(([path, entry]) =>
+      [path, entry['release-as']!] as const
+    )];
+  for (const [where, version] of pinned) {
+    yield `${where}: release-please-config.json pins "release-as": "${version}". `
+      + `A release-as pin is PERMANENT, not one-shot -- release-please proposes that exact version for every `
+      + `subsequent release, so the next breaking change would re-release ${version}. Delete the pin; to force `
+      + `one specific version once, put a \`Release-As: <version>\` footer on the commit instead.`;
+  }
+}
+
+function main(): void {
+  if (process.argv[2] !== '--check') {
+    console.error('usage: check-release-please.ts --check');
+    process.exit(2);
+  }
+
+  const problems = [...findProblems()];
+  if (problems.length === 0) {
+    console.log('release-please config and manifest agree with every publishable library.');
+    return;
+  }
+  console.error('release-please bookkeeping is out of step with the workspace:');
+  for (const problem of problems) {
+    console.error(`  - ${problem}`);
+  }
+  process.exit(1);
+}
+
+main();

--- a/scripts/publish-libraries.spec.ts
+++ b/scripts/publish-libraries.spec.ts
@@ -1,8 +1,9 @@
-// The decisions publish-libraries.ts makes without talking to npm.
+// The two decisions publish-libraries.ts makes without talking to npm: which dist-tag a version
+// publishes under, and which packages a failure strands behind it.
 
 import { describe, expect, it } from 'bun:test';
 
-import { deriveDistTag } from './publish-libraries';
+import { deriveDistTag, findBlockingDependency, type PublishOutcome } from './publish-libraries';
 
 describe('deriveDistTag', () => {
   it('sends a stable version to latest', () => {
@@ -23,5 +24,33 @@ describe('deriveDistTag', () => {
 
   it('refuses a prerelease whose identifier is purely numeric', () => {
     expect(deriveDistTag('1.0.0-0')).toBeUndefined();
+  });
+});
+
+describe('findBlockingDependency', () => {
+  it('lets a package through when every dependency landed', () => {
+    const outcomes = new Map<string, PublishOutcome>([['types', 'published'], ['func', 'already-live']]);
+    expect(findBlockingDependency(['types', 'func'], outcomes)).toBeUndefined();
+  });
+
+  it('blocks a package whose dependency failed', () => {
+    const outcomes = new Map<string, PublishOutcome>([['types', 'published'], ['collections', 'failed']]);
+    expect(findBlockingDependency(['types', 'collections'], outcomes)).toBe('collections');
+  });
+
+  it('blocks transitively as the topological walk records each outcome', () => {
+    // collections fails, iterable depends on collections, restify depends on iterable: walking in
+    // topological order, each blocked package is itself a blocker for the next.
+    const outcomes = new Map<string, PublishOutcome>([['collections', 'failed']]);
+
+    const iterableBlocker = findBlockingDependency(['collections'], outcomes);
+    expect(iterableBlocker).toBe('collections');
+    outcomes.set('iterable', 'blocked');
+
+    expect(findBlockingDependency(['iterable'], outcomes)).toBe('iterable');
+  });
+
+  it('ignores a dependency the walk has not reached yet', () => {
+    expect(findBlockingDependency(['types'], new Map<string, PublishOutcome>())).toBeUndefined();
   });
 });

--- a/scripts/publish-libraries.spec.ts
+++ b/scripts/publish-libraries.spec.ts
@@ -1,0 +1,27 @@
+// The decisions publish-libraries.ts makes without talking to npm.
+
+import { describe, expect, it } from 'bun:test';
+
+import { deriveDistTag } from './publish-libraries';
+
+describe('deriveDistTag', () => {
+  it('sends a stable version to latest', () => {
+    expect(deriveDistTag('1.0.0')).toBe('latest');
+    expect(deriveDistTag('2.11.3')).toBe('latest');
+  });
+
+  it('sends a prerelease to its own identifier', () => {
+    expect(deriveDistTag('1.2.0-placeholder.0')).toBe('placeholder');
+    expect(deriveDistTag('2.0.0-rc.1')).toBe('rc');
+    expect(deriveDistTag('3.0.0-beta')).toBe('beta');
+  });
+
+  it('reads past build metadata, which names no channel', () => {
+    expect(deriveDistTag('1.0.0+20260903')).toBe('latest');
+    expect(deriveDistTag('1.0.0-next.2+20260903')).toBe('next');
+  });
+
+  it('refuses a prerelease whose identifier is purely numeric', () => {
+    expect(deriveDistTag('1.0.0-0')).toBeUndefined();
+  });
+});

--- a/scripts/publish-libraries.ts
+++ b/scripts/publish-libraries.ts
@@ -44,8 +44,13 @@
 //   --list      print publishable names, topological order, one per line
 //   --publish   pnpm pack + npm publish each package whose version isn't live
 //
-// A failed pack, or a publish failure that is not a duplicate version, exits
-// non-zero immediately.
+// A failure does NOT abandon the rest of the run. Every package is attempted and
+// the failures are reported together at the end, non-zero -- one broken package
+// used to strand every package behind it in the topological order, packages with
+// nothing wrong with them. The single exception is a package that DEPENDS on one
+// that failed: its tarball pins the version that never landed, so publishing it
+// would install as a hard resolution failure in a consumer's project. Those are
+// skipped, and reported apart from the ordinary already-live skip.
 
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readdirSync, readFileSync } from 'node:fs';
@@ -72,6 +77,9 @@ interface Package {
   /** Workspace-sibling package names this one depends on (any dependency kind). */
   readonly deps: readonly string[];
 }
+
+/** What a run decided about one package, in the order the walk reached it. */
+export type PublishOutcome = 'published' | 'already-live' | 'failed' | 'blocked';
 
 const ROOT = `${import.meta.dir}/..`;
 const GROUP = 'libraries';
@@ -164,16 +172,29 @@ export function deriveDistTag(version: string): string | undefined {
   return /^\d+$/.test(identifier) || !identifier ? undefined : identifier;
 }
 
+/**
+ * The first dependency whose own outcome stops this package from being publishable, if any.
+ *
+ * @remarks
+ * Reaches transitive stranding for free while the walk is in topological order: a dependency
+ * blocked by ITS dependency is already recorded `blocked` by the time a dependent is looked at.
+ */
+export function findBlockingDependency(deps: Iterable<string>, outcomes: ReadonlyMap<string, PublishOutcome>): string
+  | undefined
+{
+  return Iterator.from(deps).find((dep) => outcomes.get(dep) === 'failed' || outcomes.get(dep) === 'blocked');
+}
+
 interface PackResult {
   readonly filename: string;
 }
 
 /** `pnpm pack`'s tarball path -- the publishConfig-rewritten package npm will stage. */
-function packTarball(pkg: Package, destDir: string): string {
+function packTarball(pkg: Package, destDir: string): string | undefined {
   const result = spawnSync('pnpm', ['pack', '--json', '--pack-destination', destDir], { cwd: pkg.dir });
   if (result.status !== 0) {
     process.stderr.write(result.stderr);
-    process.exit(result.status ?? 1);
+    return undefined;
   }
   return (JSON.parse(result.stdout.toString()) as PackResult).filename;
 }
@@ -207,6 +228,57 @@ function pinnedSiblings(tarball: string): Record<string, string> {
   return pinned;
 }
 
+type AttemptResult = { readonly outcome: 'published' | 'already-live'; } | { readonly outcome: 'failed';
+  readonly reason: string; };
+
+/**
+ * Packs and publishes one package, reporting what happened rather than ending the run.
+ *
+ * @param live - every `name@version` this run has confirmed on npm, read and extended in place so a
+ * sibling pinned by a later package costs at most one `npm view`.
+ */
+function attemptPublish(pkg: Package, destDir: string, live: Set<string>): AttemptResult {
+  const distTag = deriveDistTag(pkg.version);
+  if (distTag === undefined) {
+    return { outcome: 'failed', reason: `version ${pkg.version} names no dist-tag to publish under` };
+  }
+  const tarball = packTarball(pkg, destDir);
+  if (tarball === undefined) {
+    return { outcome: 'failed', reason: 'pnpm pack failed' };
+  }
+
+  // Refuse before publishing rather than after: a tarball pinning an unpublished sibling installs
+  // as a hard resolution failure downstream, and npm has no way to take it back.
+  for (const [dep, version] of Object.entries(pinnedSiblings(tarball))) {
+    if (live.has(`${dep}@${version}`)) {
+      continue;
+    }
+    const check = spawnSync('npm', ['view', `${dep}@${version}`, 'version']);
+    if (check.status === 0 && check.stdout.toString().trim()) {
+      live.add(`${dep}@${version}`);
+      continue;
+    }
+    return { outcome: 'failed',
+      reason: `pins ${dep}@${version}, which is not on npm -- its manifest is behind what was published` };
+  }
+
+  const result = spawnSync('npm', ['publish', tarball, '--provenance', '--access', 'public', '--tag', distTag], {
+    cwd: pkg.dir,
+  });
+  const output = `${result.stdout?.toString() ?? ''}${result.stderr?.toString() ?? ''}`;
+  process.stdout.write(output);
+
+  if (result.status === 0) {
+    live.add(`${pkg.name}@${pkg.version}`);
+    return { outcome: 'published' };
+  }
+  if (isAlreadyPublished(output)) {
+    live.add(`${pkg.name}@${pkg.version}`);
+    return { outcome: 'already-live' };
+  }
+  return { outcome: 'failed', reason: `npm publish exited ${result.status ?? 1}` };
+}
+
 function main(): void {
   const packages = discoverPackages();
   const ordered = computeTiers(packages).flat().map((name) => packages.get(name)!);
@@ -225,61 +297,56 @@ function main(): void {
   }
 
   const destDir = mkdtempSync(`${tmpdir()}/rhombus-publish-`);
+  const outcomes = new Map<string, PublishOutcome>();
   const published: string[] = [];
-  const skipped: string[] = [];
+  const alreadyLive: string[] = [];
+  const blocked: { name: string; dependency: string; }[] = [];
+  const failed: { name: string; reason: string; }[] = [];
   /** Versions this run has confirmed live -- either already on npm, or published moments ago. */
   const live = new Set<string>();
 
   for (const pkg of ordered) {
     console.log(`\n▶ ${pkg.name}`);
-    const distTag = deriveDistTag(pkg.version);
-    if (distTag === undefined) {
-      console.error(`publish-libraries: ${pkg.name} version ${pkg.version} names no dist-tag to publish under`);
-      process.exit(1);
-    }
-    const tarball = packTarball(pkg, destDir);
 
-    // Refuse before publishing rather than after: a tarball pinning an unpublished sibling installs
-    // as a hard resolution failure downstream, and npm has no way to take it back.
-    for (const [dep, version] of Object.entries(pinnedSiblings(tarball))) {
-      if (live.has(`${dep}@${version}`)) {
-        continue;
-      }
-      const check = spawnSync('npm', ['view', `${dep}@${version}`, 'version']);
-      if (check.status === 0 && check.stdout.toString().trim()) {
-        live.add(`${dep}@${version}`);
-        continue;
-      }
-      console.error(
-        `publish-libraries: ${pkg.name} pins ${dep}@${version}, which is not on npm. `
-          + `Its manifest is behind what was published -- sync it before publishing.`,
-      );
-      process.exit(1);
+    const blocker = findBlockingDependency(pkg.deps, outcomes);
+    if (blocker !== undefined) {
+      console.log(`- skip ${pkg.name} -- ${blocker} did not publish in this run`);
+      outcomes.set(pkg.name, 'blocked');
+      blocked.push({ name: pkg.name, dependency: blocker });
+      continue;
     }
-    const result = spawnSync('npm', ['publish', tarball, '--provenance', '--access', 'public', '--tag', distTag], {
-      cwd: pkg.dir,
-    });
-    const output = `${result.stdout?.toString() ?? ''}${result.stderr?.toString() ?? ''}`;
-    process.stdout.write(output);
 
-    if (result.status === 0) {
+    const result = attemptPublish(pkg, destDir, live);
+    outcomes.set(pkg.name, result.outcome);
+    if (result.outcome === 'published') {
       published.push(pkg.name);
-      live.add(`${pkg.name}@${pkg.version}`);
-    } else if (isAlreadyPublished(output)) {
-      live.add(`${pkg.name}@${pkg.version}`);
+    } else if (result.outcome === 'already-live') {
       // The manifest version is already live, so this package did not move in the
       // push being built. That is the steady state for most of the workspace on
       // any given commit, not a failure.
       console.log(`- skip ${pkg.name} -- version already on npm`);
-      skipped.push(pkg.name);
+      alreadyLive.push(pkg.name);
     } else {
-      console.error(`publish-libraries: ${pkg.name} failed to publish`);
-      process.exit(result.status ?? 1);
+      console.error(`publish-libraries: ${pkg.name} failed to publish -- ${result.reason}`);
+      failed.push({ name: pkg.name, reason: result.reason });
     }
   }
 
   console.log(`\npublished: ${published.join(' ') || 'none'}`);
-  console.log(`skipped:   ${skipped.join(' ') || 'none'}`);
+  console.log(`skipped:   ${alreadyLive.join(' ') || 'none'}`);
+  if (blocked.length) {
+    console.log('\nskipped -- a dependency did not publish in this run:');
+    for (const entry of blocked) {
+      console.log(`  - ${entry.name} (waiting on ${entry.dependency})`);
+    }
+  }
+  if (failed.length) {
+    console.error(`\nfailed to publish ${failed.length} package(s):`);
+    for (const entry of failed) {
+      console.error(`  - ${entry.name}: ${entry.reason}`);
+    }
+    process.exit(1);
+  }
 }
 
 if (import.meta.main) {

--- a/scripts/publish-libraries.ts
+++ b/scripts/publish-libraries.ts
@@ -14,11 +14,17 @@
 // whole run with no output, where a publish attempt that loses the race just
 // reports the duplicate and moves on.
 //
-// DIRECT publish, straight to `latest` -- deliberately NOT `npm stage publish`.
-// Staging defers proof-of-presence to a human running `npm stage approve <id>`,
-// which needs 2FA that OIDC trust tokens cannot satisfy, so a staged pipeline
-// can never complete unattended. Every @rhombus-toolkit package's npm Trusted
-// Publisher permits both; this script uses the one that finishes on its own.
+// DIRECT publish -- deliberately NOT `npm stage publish`. Staging defers
+// proof-of-presence to a human running `npm stage approve <id>`, which needs 2FA
+// that OIDC trust tokens cannot satisfy, so a staged pipeline can never complete
+// unattended. Every @rhombus-toolkit package's npm Trusted Publisher permits
+// both; this script uses the one that finishes on its own.
+//
+// The dist-tag is derived per package, never assumed: a stable version goes to
+// `latest`, a prerelease to its own identifier (`1.2.0-placeholder.0` ->
+// `placeholder`), which is the convention already on npm for this repo's
+// reservation placeholders. npm REFUSES a prerelease publish that carries no
+// `--tag` at all, so the derivation is what makes a prerelease publishable here.
 //
 // Package discovery + Kahn's-algorithm tiering are unchanged from std's shape:
 // PUBLISHABLE = has a `publishConfig` key and isn't `"private": true`, tiered
@@ -141,22 +147,21 @@ function computeTiers(packages: Map<string, Package>): string[][] {
   return tiers;
 }
 
-const packages = discoverPackages();
-const tiers = computeTiers(packages);
-const ordered = tiers.flat().map((name) => packages.get(name)!);
-
-const mode = process.argv[2];
-
-if (mode === '--list') {
-  for (const pkg of ordered) {
-    console.log(pkg.name);
+/**
+ * The npm dist-tag a version publishes under -- `latest` for a stable release, the version's own
+ * prerelease identifier otherwise (`2.0.0-rc.1` -> `rc`).
+ *
+ * @remarks
+ * `undefined` for a prerelease whose identifier is purely numeric (`1.0.0-0`): it names no channel,
+ * and npm rejects a dist-tag that parses as a semver range anyway.
+ */
+export function deriveDistTag(version: string): string | undefined {
+  const prerelease = /^[^-+]+-([^+]+)/.exec(version)?.[1];
+  if (prerelease === undefined) {
+    return 'latest';
   }
-  process.exit(0);
-}
-
-if (mode !== '--publish') {
-  console.error('usage: publish-libraries.ts --list | --publish');
-  process.exit(2);
+  const identifier = prerelease.split('.')[0] ?? '';
+  return /^\d+$/.test(identifier) || !identifier ? undefined : identifier;
 }
 
 interface PackResult {
@@ -202,52 +207,81 @@ function pinnedSiblings(tarball: string): Record<string, string> {
   return pinned;
 }
 
-const destDir = mkdtempSync(`${tmpdir()}/rhombus-publish-`);
-const published: string[] = [];
-const skipped: string[] = [];
-/** Versions this run has confirmed live -- either already on npm, or published moments ago. */
-const live = new Set<string>();
+function main(): void {
+  const packages = discoverPackages();
+  const ordered = computeTiers(packages).flat().map((name) => packages.get(name)!);
+  const mode = process.argv[2];
 
-for (const pkg of ordered) {
-  console.log(`\n▶ ${pkg.name}`);
-  const tarball = packTarball(pkg, destDir);
-
-  // Refuse before publishing rather than after: a tarball pinning an unpublished sibling installs
-  // as a hard resolution failure downstream, and npm has no way to take it back.
-  for (const [dep, version] of Object.entries(pinnedSiblings(tarball))) {
-    if (live.has(`${dep}@${version}`)) {
-      continue;
+  if (mode === '--list') {
+    for (const pkg of ordered) {
+      console.log(pkg.name);
     }
-    const check = spawnSync('npm', ['view', `${dep}@${version}`, 'version']);
-    if (check.status === 0 && check.stdout.toString().trim()) {
-      live.add(`${dep}@${version}`);
-      continue;
-    }
-    console.error(
-      `publish-libraries: ${pkg.name} pins ${dep}@${version}, which is not on npm. `
-        + `Its manifest is behind what was published -- sync it before publishing.`,
-    );
-    process.exit(1);
+    return;
   }
-  const result = spawnSync('npm', ['publish', tarball, '--provenance', '--access', 'public'], { cwd: pkg.dir });
-  const output = `${result.stdout?.toString() ?? ''}${result.stderr?.toString() ?? ''}`;
-  process.stdout.write(output);
 
-  if (result.status === 0) {
-    published.push(pkg.name);
-    live.add(`${pkg.name}@${pkg.version}`);
-  } else if (isAlreadyPublished(output)) {
-    live.add(`${pkg.name}@${pkg.version}`);
-    // The manifest version is already live, so this package did not move in the
-    // push being built. That is the steady state for most of the workspace on
-    // any given commit, not a failure.
-    console.log(`- skip ${pkg.name} -- version already on npm`);
-    skipped.push(pkg.name);
-  } else {
-    console.error(`publish-libraries: ${pkg.name} failed to publish`);
-    process.exit(result.status ?? 1);
+  if (mode !== '--publish') {
+    console.error('usage: publish-libraries.ts --list | --publish');
+    process.exit(2);
   }
+
+  const destDir = mkdtempSync(`${tmpdir()}/rhombus-publish-`);
+  const published: string[] = [];
+  const skipped: string[] = [];
+  /** Versions this run has confirmed live -- either already on npm, or published moments ago. */
+  const live = new Set<string>();
+
+  for (const pkg of ordered) {
+    console.log(`\n▶ ${pkg.name}`);
+    const distTag = deriveDistTag(pkg.version);
+    if (distTag === undefined) {
+      console.error(`publish-libraries: ${pkg.name} version ${pkg.version} names no dist-tag to publish under`);
+      process.exit(1);
+    }
+    const tarball = packTarball(pkg, destDir);
+
+    // Refuse before publishing rather than after: a tarball pinning an unpublished sibling installs
+    // as a hard resolution failure downstream, and npm has no way to take it back.
+    for (const [dep, version] of Object.entries(pinnedSiblings(tarball))) {
+      if (live.has(`${dep}@${version}`)) {
+        continue;
+      }
+      const check = spawnSync('npm', ['view', `${dep}@${version}`, 'version']);
+      if (check.status === 0 && check.stdout.toString().trim()) {
+        live.add(`${dep}@${version}`);
+        continue;
+      }
+      console.error(
+        `publish-libraries: ${pkg.name} pins ${dep}@${version}, which is not on npm. `
+          + `Its manifest is behind what was published -- sync it before publishing.`,
+      );
+      process.exit(1);
+    }
+    const result = spawnSync('npm', ['publish', tarball, '--provenance', '--access', 'public', '--tag', distTag], {
+      cwd: pkg.dir,
+    });
+    const output = `${result.stdout?.toString() ?? ''}${result.stderr?.toString() ?? ''}`;
+    process.stdout.write(output);
+
+    if (result.status === 0) {
+      published.push(pkg.name);
+      live.add(`${pkg.name}@${pkg.version}`);
+    } else if (isAlreadyPublished(output)) {
+      live.add(`${pkg.name}@${pkg.version}`);
+      // The manifest version is already live, so this package did not move in the
+      // push being built. That is the steady state for most of the workspace on
+      // any given commit, not a failure.
+      console.log(`- skip ${pkg.name} -- version already on npm`);
+      skipped.push(pkg.name);
+    } else {
+      console.error(`publish-libraries: ${pkg.name} failed to publish`);
+      process.exit(result.status ?? 1);
+    }
+  }
+
+  console.log(`\npublished: ${published.join(' ') || 'none'}`);
+  console.log(`skipped:   ${skipped.join(' ') || 'none'}`);
 }
 
-console.log(`\npublished: ${published.join(' ') || 'none'}`);
-console.log(`skipped:   ${skipped.join(' ') || 'none'}`);
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary

Three separate failures from today's release run, each fixed and each demonstrated failing first.

- **A prerelease could not be published at all.** `npm publish` was invoked with no `--tag`, which npm refuses outright for a prerelease; the error is not a duplicate-version message, so `isAlreadyPublished` let it fall through to the fatal branch. The dist-tag is now derived from the version — stable to `latest`, a prerelease to its own identifier (`1.2.0-placeholder.0` → `placeholder`), which is the convention the reservation placeholders already follow on npm.
- **One failure stranded every package behind it.** The walk exited on the first non-duplicate failure, so a `collections` failure blocked `iterable` and everything after it — packages with nothing wrong with them. Every package is attempted now, with failures collected and reported together at the end, non-zero. The exception that must hold: a dependent of a failed package is *skipped*, not attempted, because its tarball pins a version that never landed and publishing it would surface as an install-time resolution failure in a consumer's project. Topological order makes that transitive for free. Skipped-because-dependency-failed is reported apart from the ordinary already-live skip. The pinned-sibling pre-flight is unchanged in what it refuses; it just records the refusal instead of ending the run.
- **Nothing watched release-please's manifest for drift.** Publishing is keyed on `package.json` versus npm and is deliberately independent of release-please, which is exactly what lets the two separate silently — eight of twelve packages had drifted, one by a full major, with release-please still proposing releases that were already live. `scripts/check-release-please.ts --check` asserts, offline: manifest version equals `package.json` version per library; config and manifest cover exactly the publishable libraries; and no `release-as` pin anywhere. That last one is the reorg leftover four packages were carrying — a pin in config is permanent, not one-shot, and it froze `obj` at 1.0.0 so the next breaking change would have re-released the same version. Wired into `lint` next to `derive-publish-config.ts --check`.

Root `test` now runs `bun test scripts/` before the workspace filter — `--filter '*'` does not reach the root package, so the new spec would otherwise never run in CI.

## Test plan

Each fix was broken deliberately and watched go red before it went green.

- [x] `deriveDistTag` — reproduced npm's real rejection offline: `npm publish --dry-run` on a `1.2.0-placeholder.0` manifest gives `You must specify a tag using --tag when publishing a prerelease version`; the same publish with `--tag placeholder` succeeds. Reverting `deriveDistTag` to the old always-`latest` behaviour fails 3 of the 8 specs.
- [x] Failure collection — ran the real script against a stand-in `npm` on PATH that fails `type-guards` and reports every other publish as a duplicate. The script at HEAD exits at `type-guards`, never reaching `async-timers`, `iterable` or `obj`. The new one attempts `async-timers` (independent, publishes fine), skips `iterable` and `obj` as waiting on `type-guards`, and exits 1 with the summary.
- [x] Pinned-sibling pre-flight — marked `types` private so it drops out of the walk, with a stand-in `npm view` finding nothing: four packages fail with `pins @rhombus-toolkit/types@1.0.1, which is not on npm`, and their dependents are skipped.
- [x] `check-release-please.ts` — three separate breaks, each caught, exit 1, restored clean: `obj`'s manifest entry set to 1.0.0 against its 3.0.0 `package.json`; `once` removed from both files plus a stale `libraries/case-converter` entry added; a `"release-as": "1.0.0"` pin added to `obj`.
- [x] `bun install`, `bun run build`, `bun run typecheck`, `bun run lint`, `bun run test`, `bun run format:check` — all green on the rebased branch.